### PR TITLE
Style: data_types

### DIFF
--- a/vunit/builtins.py
+++ b/vunit/builtins.py
@@ -72,6 +72,7 @@ class Builtins(object):
         """
         Add data types packages
         """
+        self._add_files(join(VHDL_PATH, "data_types", "src", "types", "*.vhd"))
         self._add_files(join(VHDL_PATH, "data_types", "src", "*.vhd"))
 
     def _add_array_util(self):

--- a/vunit/vhdl/com/src/com_string.vhd
+++ b/vunit/vhdl/com/src/com_string.vhd
@@ -217,7 +217,7 @@ package body com_string_pkg is
     constant data : integer_vector_ptr_t)
     return string is
   begin
-    return create_group(1, to_string(data.index));
+    return create_group(1, to_string(data.ref));
   end;
 
   function to_string (

--- a/vunit/vhdl/data_types/src/dict_pkg.vhd
+++ b/vunit/vhdl/data_types/src/dict_pkg.vhd
@@ -18,14 +18,43 @@ package dict_pkg is
   end record;
   constant null_dict : dict_t := (others => null_ptr);
 
-  impure function new_dict return dict_t;
-  procedure deallocate(variable dict : inout dict_t);
+  impure function
+  new_dict
+  return dict_t;
 
-  procedure set(dict : dict_t; key, value : string);
-  impure function get(dict : dict_t; key : string) return string;
-  impure function has_key(dict : dict_t; key : string) return boolean;
-  impure function num_keys(dict : dict_t) return natural;
-  procedure remove(dict : dict_t; key : string);
+  procedure
+  deallocate(
+    variable dict : inout dict_t
+  );
+
+  procedure
+  set(
+    dict       : dict_t;
+    key, value : string
+  );
+
+  impure function
+  get(
+    dict : dict_t;
+    key  : string
+  ) return string;
+
+  impure function
+  has_key(
+    dict : dict_t;
+    key  : string
+  ) return boolean;
+
+  impure function
+  num_keys(
+    dict : dict_t
+  ) return natural;
+
+  procedure
+  remove(
+    dict : dict_t;
+    key  : string
+  );
 end package;
 
 package body dict_pkg is
@@ -37,7 +66,9 @@ package body dict_pkg is
 
   constant new_bucket_size : natural := 1;
 
-  impure function new_dict return dict_t is
+  impure function
+  new_dict
+  return dict_t is
     variable dict : dict_t;
     variable tmp : integer_vector_ptr_t;
     constant num_buckets : natural := 1;
@@ -60,9 +91,12 @@ package body dict_pkg is
       set(dict.p_bucket_values, i, to_integer(tmp));
     end loop;
     return dict;
-  end function;
+  end;
 
-  procedure deallocate(variable dict : inout dict_t) is
+  procedure
+  deallocate(
+    variable dict : inout dict_t
+  ) is
     constant num_buckets : natural := length(dict.p_bucket_lengths);
 
     variable bucket_values : integer_vector_ptr_t;
@@ -97,16 +131,24 @@ package body dict_pkg is
   end;
 
   -- DJB2 hash
-  impure function hash(str : string) return natural is
+  impure function
+  hash(
+    str : string
+  ) return natural is
     variable value : natural := 5381;
   begin
     for i in str'range loop
       value := (33*value + character'pos(str(i))) mod 2**(31-6);
     end loop;
     return value;
-  end function;
+  end;
 
-  impure function get_value_ptr(dict : dict_t; key_hash : natural; key : string) return string_ptr_t is
+  impure function
+  get_value_ptr(
+    dict     : dict_t;
+    key_hash : natural;
+    key      : string
+  ) return string_ptr_t is
     constant num_buckets : natural := length(dict.p_bucket_lengths);
     constant bucket_idx : natural := key_hash mod num_buckets;
 
@@ -123,7 +165,13 @@ package body dict_pkg is
     return null_string_ptr;
   end;
 
-  procedure remove(dict : dict_t; bucket_idx : natural; i : natural; deallocate_item : boolean := true) is
+  procedure
+  remove(
+    dict            : dict_t;
+    bucket_idx      : natural;
+    i               : natural;
+    deallocate_item : boolean := true
+  ) is
     constant bucket_length : natural := get(dict.p_bucket_lengths, bucket_idx);
     constant bucket_values : integer_vector_ptr_t := to_integer_vector_ptr(get(dict.p_bucket_values, bucket_idx));
     constant bucket_keys : integer_vector_ptr_t := to_integer_vector_ptr(get(dict.p_bucket_keys, bucket_idx));
@@ -145,7 +193,12 @@ package body dict_pkg is
     set(dict.p_meta, meta_num_keys, num_keys(dict)-1);
   end;
 
-  procedure remove(dict : dict_t; key_hash : natural; key : string) is
+  procedure
+  remove(
+    dict     : dict_t;
+    key_hash : natural;
+    key      : string
+  ) is
     constant num_buckets : natural := length(dict.p_bucket_lengths);
     constant bucket_idx : natural := key_hash mod num_buckets;
 
@@ -160,9 +213,18 @@ package body dict_pkg is
     end loop;
   end;
 
-  procedure insert_new(dict : dict_t; key_hash : natural; key, value : string_ptr_t);
+  procedure
+  insert_new(
+    dict       : dict_t;
+    key_hash   : natural;
+    key, value : string_ptr_t
+  );
 
-  procedure relocate_items(dict : dict_t; old_num_buckets : natural) is
+  procedure
+  relocate_items(
+    dict : dict_t;
+    old_num_buckets : natural
+  ) is
     constant num_buckets : natural := length(dict.p_bucket_lengths);
     variable bucket_values : integer_vector_ptr_t;
     variable bucket_keys : integer_vector_ptr_t;
@@ -199,7 +261,11 @@ package body dict_pkg is
     end loop;
   end;
 
-  procedure resize(dict : dict_t; num_buckets : natural) is
+  procedure
+  resize(
+    dict : dict_t;
+    num_buckets : natural
+  ) is
     constant old_num_buckets : natural := length(dict.p_bucket_lengths);
   begin
     resize(dict.p_bucket_lengths, num_buckets);
@@ -216,7 +282,11 @@ package body dict_pkg is
     relocate_items(dict, old_num_buckets);
   end;
 
-  procedure set(dict : dict_t; key, value : string) is
+  procedure
+  set(
+    dict : dict_t;
+    key, value : string
+  ) is
     constant key_hash : natural := hash(key);
     constant old_value_ptr : string_ptr_t := get_value_ptr(dict, key_hash, key);
   begin
@@ -228,7 +298,12 @@ package body dict_pkg is
     end if;
   end;
 
-  procedure insert_new(dict : dict_t; key_hash : natural; key, value : string_ptr_t) is
+  procedure
+  insert_new(
+    dict       : dict_t;
+    key_hash   : natural;
+    key, value : string_ptr_t
+  ) is
     constant num_buckets : natural := length(dict.p_bucket_lengths);
     constant bucket_idx : natural := key_hash mod num_buckets;
 
@@ -258,9 +333,13 @@ package body dict_pkg is
     -- Create new value storage
     set(bucket_keys, bucket_length, to_integer(key));
     set(bucket_values, bucket_length, to_integer(value));
-  end procedure;
+  end;
 
-  impure function get(dict : dict_t; key : string) return string is
+  impure function
+  get(
+    dict : dict_t;
+    key  : string
+  ) return string is
     constant key_hash : natural := hash(key);
     constant value_ptr : string_ptr_t := get_value_ptr(dict, key_hash, key);
   begin
@@ -268,20 +347,30 @@ package body dict_pkg is
     return to_string(value_ptr);
   end;
 
-  impure function has_key(dict : dict_t; key : string) return boolean is
+  impure function
+  has_key(
+    dict : dict_t;
+    key  : string
+  ) return boolean is
     constant key_hash : natural := hash(key);
   begin
     return get_value_ptr(dict, key_hash, key) /= null_string_ptr;
   end;
 
-  procedure remove(dict : dict_t; key : string) is
+  procedure
+  remove(
+    dict : dict_t;
+    key  : string
+  ) is
     constant key_hash : natural := hash(key);
   begin
     remove(dict, key_hash, key);
   end;
 
-  impure function num_keys(dict : dict_t) return natural is
-  begin
+  impure function
+  num_keys(
+    dict : dict_t
+  ) return natural is begin
     return get(dict.p_meta, meta_num_keys);
   end;
 

--- a/vunit/vhdl/data_types/src/integer_array_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/integer_array_pkg-body.vhd
@@ -9,25 +9,33 @@ use std.textio.all;
 package body integer_array_pkg is
   type binary_file_t is file of character;
 
-  procedure read_byte(file fread : binary_file_t;
-                      variable result : out integer) is
+  procedure
+  read_byte(
+    file fread : binary_file_t;
+    variable result : out integer
+  ) is
     variable chr : character;
   begin
     assert not endfile(fread) report "Premature end of file";
     read(fread, chr);
     result := character'pos(chr);
-  end procedure;
+  end;
 
-  procedure write_byte(file fwrite : binary_file_t;
-                       value : natural range 0 to 255) is
-  begin
+  procedure
+  write_byte(
+    file fwrite : binary_file_t;
+    value : natural range 0 to 255
+  ) is begin
     write(fwrite, character'val(value));
-  end procedure;
+  end;
 
-  procedure read_integer(file fread : binary_file_t;
-                         variable result : out integer;
-                         bytes_per_word : natural range 1 to 4 := 4;
-                         is_signed : boolean := true) is
+  procedure
+  read_integer(
+    file fread : binary_file_t;
+    variable result : out integer;
+    bytes_per_word : natural range 1 to 4 := 4;
+    is_signed : boolean := true
+  ) is
     variable tmp, byte : integer;
   begin
     tmp := 0;
@@ -39,12 +47,15 @@ package body integer_array_pkg is
       tmp := tmp + byte*256**i;
     end loop;
     result := tmp;
-  end procedure;
+  end;
 
-  procedure write_integer(file fwrite : binary_file_t;
-                          value : integer;
-                          bytes_per_word : natural range 1 to 4 := 4;
-                          is_signed : boolean := true) is
+  procedure
+  write_integer(
+    file fwrite    : binary_file_t;
+    value          : integer;
+    bytes_per_word : natural range 1 to 4 := 4;
+    is_signed      : boolean := true
+  ) is
     variable tmp, byte : integer;
   begin
     tmp := value;
@@ -53,78 +64,107 @@ package body integer_array_pkg is
       write_byte(fwrite, byte);
       tmp := (tmp - byte)/256;
     end loop;
-  end procedure;
+  end;
 
-  impure function length(arr : integer_array_t) return integer is
-  begin
+  impure function
+  length(
+    arr : integer_array_t
+  ) return integer is begin
     return arr.length;
-  end function;
+  end;
 
-  impure function width(arr : integer_array_t) return integer is
-  begin
+  impure function
+  width(
+    arr : integer_array_t
+  ) return integer is begin
     return arr.width;
-  end function;
+  end;
 
-  impure function height(arr : integer_array_t) return integer is
-  begin
+  impure function
+  height(
+    arr : integer_array_t
+  ) return integer is begin
     return arr.height;
-  end function;
+  end;
 
-  impure function depth(arr : integer_array_t) return integer is
-  begin
+  impure function
+  depth(
+    arr : integer_array_t
+  ) return integer is begin
     return arr.depth;
-  end function;
+  end;
 
-  impure function bit_width(arr : integer_array_t) return integer is
-  begin
+  impure function
+  bit_width(
+    arr : integer_array_t
+  ) return integer is begin
     return arr.bit_width;
-  end function;
+  end;
 
-  impure function is_signed(arr : integer_array_t) return boolean is
-  begin
+  impure function
+  is_signed(
+    arr : integer_array_t
+  ) return boolean is begin
     return arr.is_signed;
-  end function;
+  end;
 
-  impure function bytes_per_word(arr : integer_array_t) return integer is
-  begin
+  impure function
+  bytes_per_word(
+    arr : integer_array_t
+  ) return integer is begin
     return (arr.bit_width + 7)/8;
-  end function;
+  end;
 
-  impure function lower_limit(arr : integer_array_t) return integer is
-  begin
+  impure function
+  lower_limit(
+    arr : integer_array_t
+  ) return integer is begin
     return arr.lower_limit;
-  end function;
+  end;
 
-  impure function upper_limit(arr : integer_array_t) return integer is
-  begin
+  impure function
+  upper_limit(
+    arr : integer_array_t
+  ) return integer is begin
     return arr.upper_limit;
-  end function;
+  end;
 
-  procedure validate_data(arr : integer_array_t) is
-  begin
+  procedure
+  validate_data(
+    arr : integer_array_t
+  ) is begin
     assert arr.data /= null_ptr report "Data is not allocated";
-  end procedure;
+  end;
 
-  procedure validate_bounds(name : string; val, bound : integer) is
-  begin
+  procedure
+  validate_bounds(
+    name       : string;
+    val, bound : integer
+  ) is begin
     assert 0 <= val and val < bound
-                report (name & "=" & integer'image(val) & " " &
-                        "is out of bounds " &
-                        "0 <= " & name  &" < " & integer'image(bound));
-  end procedure;
+      report (name & "=" & integer'image(val) & " " &
+              "is out of bounds " &
+              "0 <= " & name  &" < " & integer'image(bound));
+  end;
 
-  procedure validate_value(arr : integer_array_t; value : integer) is
-  begin
+  procedure
+  validate_value(
+    arr   : integer_array_t;
+    value : integer
+  ) is begin
     assert arr.lower_limit <= value and value <= arr.upper_limit
-                                 report ("value=" & integer'image(value) & " " &
-                                         "is out of bounds " &
-                                         integer'image(arr.lower_limit) &
-                                         " <= value <= " &
-                                         integer'image(arr.upper_limit));
-  end procedure;
+      report ("value=" & integer'image(value) & " " &
+              "is out of bounds " &
+              integer'image(arr.lower_limit) &
+              " <= value <= " &
+              integer'image(arr.upper_limit));
+  end;
 
-  procedure realloc(variable arr : inout integer_array_t; new_length : integer) is
-  begin
+  procedure
+  realloc(
+    variable arr : inout integer_array_t;
+    new_length : integer
+  ) is begin
     if arr.data = null_ptr then
       -- Array was empty
       arr.data := new_integer_vector_ptr(new_length);
@@ -135,87 +175,122 @@ package body integer_array_pkg is
     end if;
 
     arr.length := new_length;
-  end procedure;
+  end;
 
-  procedure reshape(variable arr : inout integer_array_t; length : integer) is
-  begin
+  procedure
+  reshape(
+    variable arr : inout integer_array_t;
+    length : integer
+  ) is begin
     reshape(arr, length, 1, 1);
-  end procedure;
+  end;
 
-  procedure reshape(variable arr : inout integer_array_t; width, height : integer) is
-  begin
+  procedure
+  reshape(
+    variable arr  : inout integer_array_t;
+    width, height : integer
+  ) is begin
     reshape(arr, width, height, 1);
-  end procedure;
+  end;
 
-  procedure reshape(variable arr : inout integer_array_t; width, height, depth : integer) is
-  begin
+  procedure
+  reshape(
+    variable arr : inout integer_array_t;
+    width, height, depth : integer
+  ) is begin
     arr.width := width;
     arr.height := height;
     arr.depth := depth;
     realloc(arr, width*height*depth);
-  end procedure;
+  end;
 
-  procedure append(variable arr : inout integer_array_t; value : integer) is
-  begin
+  procedure
+  append(
+    variable arr : inout integer_array_t;
+    value : integer
+  ) is begin
     reshape(arr, arr.length+1);
     set(arr, arr.length-1, value);
-  end procedure;
+  end;
 
-  impure function get(arr : integer_array_t; idx : integer) return integer is
-  begin
+  impure function
+  get(
+    arr : integer_array_t;
+    idx : integer
+  ) return integer is begin
     validate_data(arr);
     validate_bounds("idx", idx, arr.length);
     return get(arr.data, idx);
-  end function;
+  end;
 
-  impure function get(arr : integer_array_t; x, y : integer) return integer is
-  begin
+  impure function
+  get(
+    arr  : integer_array_t;
+    x, y : integer
+  ) return integer is begin
     validate_data(arr);
     validate_bounds("x", x, arr.width);
     validate_bounds("y", y, arr.height);
     return get(arr.data, y*arr.width + x);
-  end function;
+  end;
 
-  impure function get(arr : integer_array_t; x,y,z : integer) return integer is
-  begin
+  impure function
+  get(
+    arr   : integer_array_t;
+    x,y,z : integer
+  ) return integer is begin
     validate_data(arr);
     validate_bounds("x", x, arr.width);
     validate_bounds("y", y, arr.height);
     validate_bounds("z", z, arr.depth);
     return get(arr.data, (y*arr.width + x)*arr.depth + z);
-  end function;
+  end;
 
-  procedure set(arr : integer_array_t; idx : integer; value : integer)  is
-  begin
+  procedure
+  set(
+    arr   : integer_array_t;
+    idx   : integer;
+    value : integer
+  ) is begin
     validate_data(arr);
     validate_bounds("idx", idx, arr.length);
     validate_value(arr, value);
     set(arr.data, idx, value);
-  end procedure;
+  end;
 
-  procedure set(arr : integer_array_t; x,y : integer; value : integer)  is
-  begin
+  procedure
+  set(
+    arr   : integer_array_t;
+    x,y   : integer;
+    value : integer
+  ) is begin
     validate_data(arr);
     validate_bounds("x", x, arr.width);
     validate_bounds("y", y, arr.height);
     validate_value(arr, value);
     set(arr.data, y*arr.width + x, value);
-  end procedure;
+  end;
 
-  procedure set(arr : integer_array_t; x,y,z : integer; value : integer)  is
-  begin
+  procedure
+  set(
+    arr   : integer_array_t;
+    x,y,z : integer;
+    value : integer
+  ) is begin
     validate_data(arr);
     validate_bounds("x", x, arr.width);
     validate_bounds("y", y, arr.height);
     validate_bounds("z", z, arr.depth);
     validate_value(arr, value);
     set(arr.data, (y*arr.width + x)*arr.depth + z, value);
-  end procedure;
+  end;
 
-  procedure set_word_size(variable arr : inout integer_array_t;
-                          bit_width : natural := 32;
-                          is_signed : boolean := true) is
-  begin
+  procedure
+  set_word_size(
+    variable arr : inout integer_array_t;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) is begin
     assert (1 <= bit_width and bit_width < 32) or (bit_width = 32 and is_signed)
       report "Unsupported combination of bit_width and is_signed";
     arr.bit_width := bit_width;
@@ -238,12 +313,14 @@ package body integer_array_pkg is
         arr.upper_limit := 2**arr.bit_width-1;
       end if;
     end if;
-  end procedure;
+  end;
 
-  impure function new_1d(length : integer := 0;
-                         bit_width : natural := 32;
-                         is_signed : boolean := true) return integer_array_t is
-  begin
+  impure function
+  new_1d(
+    length    : integer := 0;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t is begin
     return new_3d(width => length,
                   height => 1,
                   depth => 1,
@@ -251,11 +328,13 @@ package body integer_array_pkg is
                   is_signed => is_signed);
   end;
 
-  impure function new_2d(width : integer := 0;
-                         height : integer := 0;
-                         bit_width : natural := 32;
-                         is_signed : boolean := true) return integer_array_t is
-  begin
+  impure function
+  new_2d(
+    width     : integer := 0;
+    height    : integer := 0;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t is begin
     return new_3d(width => width,
                   height => height,
                   depth => 1,
@@ -263,11 +342,14 @@ package body integer_array_pkg is
                   is_signed => is_signed);
   end;
 
-  impure function new_3d(width : integer := 0;
-                         height : integer := 0;
-                         depth : integer := 0;
-                         bit_width : natural := 32;
-                         is_signed : boolean := true) return integer_array_t is
+  impure function
+  new_3d(
+    width     : integer := 0;
+    height    : integer := 0;
+    depth     : integer := 0;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t is
     variable arr : integer_array_t := null_integer_array;
   begin
     set_word_size(arr, bit_width, is_signed);
@@ -286,7 +368,10 @@ package body integer_array_pkg is
     return arr;
   end;
 
-  impure function copy(arr : integer_array_t) return integer_array_t is
+  impure function
+  copy(
+    arr : integer_array_t
+  ) return integer_array_t is
     variable arr_copy : integer_array_t;
   begin
     arr_copy := new_3d(arr.width, arr.height,
@@ -297,20 +382,28 @@ package body integer_array_pkg is
     return arr_copy;
   end;
 
-  procedure deallocate(variable arr : inout integer_array_t) is
-  begin
+  procedure
+  deallocate(
+    variable arr : inout integer_array_t
+  ) is begin
     if arr.data /= null_ptr then
       deallocate(arr.data);
     end if;
     arr := null_integer_array;
-  end procedure;
+  end;
 
-  impure function is_null(arr : integer_array_t) return boolean is
-  begin
+  impure function
+  is_null(
+    arr : integer_array_t
+  ) return boolean is begin
     return arr = null_integer_array;
-  end function;
+  end;
 
-  procedure save_csv(arr : integer_array_t; file_name : string) is
+  procedure
+  save_csv(
+    arr       : integer_array_t;
+    file_name : string
+  ) is
     file fwrite : text;
     variable l : line;
   begin
@@ -327,19 +420,22 @@ package body integer_array_pkg is
       writeline(fwrite, l);
     end loop;
     file_close(fwrite);
-  end procedure;
+  end;
 
-  impure function load_csv(file_name : string;
-                           bit_width : natural := 32;
-                           is_signed : boolean := true) return integer_array_t is
-    variable arr : integer_array_t;
-    file fread : text;
-    variable l : line;
-    variable tmp : integer;
-    variable ctmp : character;
+  impure function
+  load_csv(
+    file_name : string;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t is
+    variable arr     : integer_array_t;
+    file     fread   : text;
+    variable l       : line;
+    variable tmp     : integer;
+    variable ctmp    : character;
     variable is_good : boolean;
-    variable width : integer := 0;
-    variable height : integer := 0;
+    variable width   : integer := 0;
+    variable height  : integer := 0;
   begin
     arr := new_1d(bit_width => bit_width, is_signed => is_signed);
     file_open(fread, file_name, read_mode);
@@ -362,7 +458,11 @@ package body integer_array_pkg is
     return arr;
   end;
 
-  procedure save_raw(arr : integer_array_t; file_name : string) is
+  procedure
+  save_raw(
+    arr       : integer_array_t;
+    file_name : string
+  ) is
     file fwrite : binary_file_t;
   begin
     file_open(fwrite, file_name, write_mode);
@@ -373,11 +473,14 @@ package body integer_array_pkg is
                     is_signed => arr.is_signed);
     end loop;
     file_close(fwrite);
-  end procedure;
+  end;
 
-  impure function load_raw(file_name : string;
-                           bit_width : natural := 32;
-                           is_signed : boolean := true) return integer_array_t is
+  impure function
+  load_raw(
+    file_name : string;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t is
     variable arr : integer_array_t;
     file fread : binary_file_t;
     variable tmp : integer;

--- a/vunit/vhdl/data_types/src/integer_array_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/integer_array_pkg-body.vhd
@@ -9,9 +9,8 @@ use std.textio.all;
 package body integer_array_pkg is
   type binary_file_t is file of character;
 
-  procedure
-  read_byte(
-    file fread : binary_file_t;
+  procedure read_byte (
+    file fread      : binary_file_t;
     variable result : out integer
   ) is
     variable chr : character;
@@ -21,20 +20,18 @@ package body integer_array_pkg is
     result := character'pos(chr);
   end;
 
-  procedure
-  write_byte(
+  procedure write_byte (
     file fwrite : binary_file_t;
-    value : natural range 0 to 255
+    value       : natural range 0 to 255
   ) is begin
     write(fwrite, character'val(value));
   end;
 
-  procedure
-  read_integer(
-    file fread : binary_file_t;
+  procedure read_integer (
+    file fread      : binary_file_t;
     variable result : out integer;
-    bytes_per_word : natural range 1 to 4 := 4;
-    is_signed : boolean := true
+    bytes_per_word  : natural range 1 to 4 := 4;
+    is_signed       : boolean := true
   ) is
     variable tmp, byte : integer;
   begin
@@ -49,8 +46,7 @@ package body integer_array_pkg is
     result := tmp;
   end;
 
-  procedure
-  write_integer(
+  procedure write_integer (
     file fwrite    : binary_file_t;
     value          : integer;
     bytes_per_word : natural range 1 to 4 := 4;
@@ -66,78 +62,67 @@ package body integer_array_pkg is
     end loop;
   end;
 
-  impure function
-  length(
+  impure function length (
     arr : integer_array_t
   ) return integer is begin
     return arr.length;
   end;
 
-  impure function
-  width(
+  impure function width (
     arr : integer_array_t
   ) return integer is begin
     return arr.width;
   end;
 
-  impure function
-  height(
+  impure function height (
     arr : integer_array_t
   ) return integer is begin
     return arr.height;
   end;
 
-  impure function
-  depth(
+  impure function depth (
     arr : integer_array_t
   ) return integer is begin
     return arr.depth;
   end;
 
-  impure function
-  bit_width(
+  impure function bit_width (
     arr : integer_array_t
   ) return integer is begin
     return arr.bit_width;
   end;
 
-  impure function
-  is_signed(
+  impure function is_signed (
     arr : integer_array_t
   ) return boolean is begin
     return arr.is_signed;
   end;
 
-  impure function
-  bytes_per_word(
+  impure function bytes_per_word (
     arr : integer_array_t
   ) return integer is begin
     return (arr.bit_width + 7)/8;
   end;
 
-  impure function
-  lower_limit(
+  impure function lower_limit (
     arr : integer_array_t
   ) return integer is begin
     return arr.lower_limit;
   end;
 
-  impure function
-  upper_limit(
+  impure function upper_limit (
     arr : integer_array_t
   ) return integer is begin
     return arr.upper_limit;
   end;
 
-  procedure
-  validate_data(
+  procedure validate_data (
     arr : integer_array_t
   ) is begin
     assert arr.data /= null_ptr report "Data is not allocated";
   end;
 
-  procedure
-  validate_bounds(
+  procedure validate_bounds (
     name       : string;
     val, bound : integer
   ) is begin
@@ -147,8 +132,7 @@ package body integer_array_pkg is
               "0 <= " & name  &" < " & integer'image(bound));
   end;
 
-  procedure
-  validate_value(
+  procedure validate_value (
     arr   : integer_array_t;
     value : integer
   ) is begin
@@ -160,10 +144,9 @@ package body integer_array_pkg is
               integer'image(arr.upper_limit));
   end;
 
-  procedure
-  realloc(
+  procedure realloc (
     variable arr : inout integer_array_t;
-    new_length : integer
+    new_length   : integer
   ) is begin
     if arr.data = null_ptr then
       -- Array was empty
@@ -173,29 +156,25 @@ package body integer_array_pkg is
       -- Add extra length to avoid excessive reallocation when appending
       resize(arr.data, new_length + length(arr.data));
     end if;
-
     arr.length := new_length;
   end;
 
-  procedure
-  reshape(
+  procedure reshape (
     variable arr : inout integer_array_t;
-    length : integer
+    length       : integer
   ) is begin
     reshape(arr, length, 1, 1);
   end;
 
-  procedure
-  reshape(
+  procedure reshape (
     variable arr  : inout integer_array_t;
     width, height : integer
   ) is begin
     reshape(arr, width, height, 1);
   end;
 
-  procedure
-  reshape(
-    variable arr : inout integer_array_t;
+  procedure reshape (
+    variable arr         : inout integer_array_t;
     width, height, depth : integer
   ) is begin
     arr.width := width;
@@ -204,17 +183,15 @@ package body integer_array_pkg is
     realloc(arr, width*height*depth);
   end;
 
-  procedure
-  append(
+  procedure append (
     variable arr : inout integer_array_t;
-    value : integer
+    value        : integer
   ) is begin
     reshape(arr, arr.length+1);
     set(arr, arr.length-1, value);
   end;
 
-  impure function
-  get(
+  impure function get (
     arr : integer_array_t;
     idx : integer
   ) return integer is begin
@@ -223,8 +200,7 @@ package body integer_array_pkg is
     return get(arr.data, idx);
   end;
 
-  impure function
-  get(
+  impure function get (
     arr  : integer_array_t;
     x, y : integer
   ) return integer is begin
@@ -234,8 +210,7 @@ package body integer_array_pkg is
     return get(arr.data, y*arr.width + x);
   end;
 
-  impure function
-  get(
+  impure function get (
     arr   : integer_array_t;
     x,y,z : integer
   ) return integer is begin
@@ -246,8 +221,7 @@ package body integer_array_pkg is
     return get(arr.data, (y*arr.width + x)*arr.depth + z);
   end;
 
-  procedure
-  set(
+  procedure set (
     arr   : integer_array_t;
     idx   : integer;
     value : integer
@@ -258,8 +232,7 @@ package body integer_array_pkg is
     set(arr.data, idx, value);
   end;
 
-  procedure
-  set(
+  procedure set (
     arr   : integer_array_t;
     x,y   : integer;
     value : integer
@@ -271,8 +244,7 @@ package body integer_array_pkg is
     set(arr.data, y*arr.width + x, value);
   end;
 
-  procedure
-  set(
+  procedure set (
     arr   : integer_array_t;
     x,y,z : integer;
     value : integer
@@ -285,17 +257,15 @@ package body integer_array_pkg is
     set(arr.data, (y*arr.width + x)*arr.depth + z, value);
   end;
 
-  procedure
-  set_word_size(
+  procedure set_word_size (
     variable arr : inout integer_array_t;
-    bit_width : natural := 32;
-    is_signed : boolean := true
+    bit_width    : natural := 32;
+    is_signed    : boolean := true
   ) is begin
     assert (1 <= bit_width and bit_width < 32) or (bit_width = 32 and is_signed)
       report "Unsupported combination of bit_width and is_signed";
     arr.bit_width := bit_width;
     arr.is_signed := is_signed;
-
     if arr.is_signed then
       if arr.bit_width = 32 then
         -- avoid overflow warning
@@ -315,8 +285,7 @@ package body integer_array_pkg is
     end if;
   end;
 
-  impure function
-  new_1d(
+  impure function new_1d (
     length    : integer := 0;
     bit_width : natural := 32;
     is_signed : boolean := true
@@ -328,8 +297,7 @@ package body integer_array_pkg is
                   is_signed => is_signed);
   end;
 
-  impure function
-  new_2d(
+  impure function new_2d (
     width     : integer := 0;
     height    : integer := 0;
     bit_width : natural := 32;
@@ -342,8 +310,7 @@ package body integer_array_pkg is
                   is_signed => is_signed);
   end;
 
-  impure function
-  new_3d(
+  impure function new_3d (
     width     : integer := 0;
     height    : integer := 0;
     depth     : integer := 0;
@@ -353,23 +320,19 @@ package body integer_array_pkg is
     variable arr : integer_array_t := null_integer_array;
   begin
     set_word_size(arr, bit_width, is_signed);
-
     arr.length := width * height * depth;
     arr.width := width;
     arr.height := height;
     arr.depth := depth;
-
     if arr.length > 0 then
       arr.data := new_integer_vector_ptr(arr.length);
     else
       arr.data := null_ptr;
     end if;
-
     return arr;
   end;
 
-  impure function
-  copy(
+  impure function copy (
     arr : integer_array_t
   ) return integer_array_t is
     variable arr_copy : integer_array_t;
@@ -382,8 +345,7 @@ package body integer_array_pkg is
     return arr_copy;
   end;
 
-  procedure
-  deallocate(
+  procedure deallocate (
     variable arr : inout integer_array_t
   ) is begin
     if arr.data /= null_ptr then
@@ -392,15 +354,13 @@ package body integer_array_pkg is
     arr := null_integer_array;
   end;
 
-  impure function
-  is_null(
+  impure function is_null (
     arr : integer_array_t
   ) return boolean is begin
     return arr = null_integer_array;
   end;
 
-  procedure
-  save_csv(
+  procedure save_csv (
     arr       : integer_array_t;
     file_name : string
   ) is
@@ -422,8 +382,7 @@ package body integer_array_pkg is
     file_close(fwrite);
   end;
 
-  impure function
-  load_csv(
+  impure function load_csv (
     file_name : string;
     bit_width : natural := 32;
     is_signed : boolean := true
@@ -458,8 +417,7 @@ package body integer_array_pkg is
     return arr;
   end;
 
-  procedure
-  save_raw(
+  procedure save_raw (
     arr       : integer_array_t;
     file_name : string
   ) is
@@ -475,8 +433,7 @@ package body integer_array_pkg is
     file_close(fwrite);
   end;
 
-  impure function
-  load_raw(
+  impure function load_raw (
     file_name : string;
     bit_width : natural := 32;
     is_signed : boolean := true

--- a/vunit/vhdl/data_types/src/integer_array_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_array_pkg.vhd
@@ -7,7 +7,6 @@
 use work.integer_vector_ptr_pkg.all;
 
 package integer_array_pkg is
-
   type integer_array_t is record
     -- All fields are considered private, use functions to access these
     length : natural;
@@ -36,55 +35,176 @@ package integer_array_pkg is
 
   type integer_array_vec_t is array (natural range <>) of integer_array_t;
 
-  impure function new_1d(length : integer := 0;
-                         bit_width : natural := 32;
-                         is_signed : boolean := true) return integer_array_t;
+  impure function
+  new_1d(
+    length    : integer := 0;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t;
 
-  impure function new_2d(width : integer := 0;
-                         height : integer := 0;
-                         bit_width : natural := 32;
-                         is_signed : boolean := true) return integer_array_t;
+  impure function
+  new_2d(
+    width     : integer := 0;
+    height    : integer := 0;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t;
 
-  impure function new_3d(width : integer := 0;
-                         height : integer := 0;
-                         depth : integer := 0;
-                         bit_width : natural := 32;
-                         is_signed : boolean := true) return integer_array_t;
+  impure function
+  new_3d(
+    width     : integer := 0;
+    height    : integer := 0;
+    depth     : integer := 0;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t;
 
-  impure function copy(arr : integer_array_t) return integer_array_t;
+  impure function
+  copy(
+    arr : integer_array_t
+  ) return integer_array_t;
 
-  impure function load_csv(file_name : string;
-                           bit_width : natural := 32;
-                           is_signed : boolean := true) return integer_array_t;
+  impure function
+  load_csv(
+    file_name : string;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t;
 
-  impure function load_raw(file_name : string;
-                           bit_width : natural := 32;
-                           is_signed : boolean := true) return integer_array_t;
-  procedure deallocate(variable arr : inout integer_array_t);
-  impure function is_null(arr : integer_array_t) return boolean;
+  impure function
+  load_raw(
+    file_name : string;
+    bit_width : natural := 32;
+    is_signed : boolean := true
+  ) return integer_array_t;
 
-  impure function length(arr : integer_array_t) return integer;
-  impure function width(arr : integer_array_t) return integer;
-  impure function height(arr : integer_array_t) return integer;
-  impure function depth(arr : integer_array_t) return integer;
-  impure function bit_width(arr : integer_array_t) return integer;
-  impure function is_signed(arr : integer_array_t) return boolean;
-  impure function bytes_per_word(arr : integer_array_t) return integer;
-  impure function lower_limit(arr : integer_array_t) return integer;
-  impure function upper_limit(arr : integer_array_t) return integer;
+  procedure
+  deallocate(
+    variable arr : inout integer_array_t
+  );
 
-  impure function get(arr : integer_array_t; idx : integer) return integer;
-  impure function get(arr : integer_array_t; x,y : integer) return integer;
-  impure function get(arr : integer_array_t; x,y,z : integer) return integer;
+  impure function
+  is_null(
+    arr : integer_array_t
+  ) return boolean;
 
-  procedure set(arr : integer_array_t; idx : integer; value : integer);
-  procedure set(arr : integer_array_t; x,y : integer; value : integer);
-  procedure set(arr : integer_array_t; x,y,z : integer; value : integer);
+  impure function
+  length(
+    arr : integer_array_t
+  ) return integer;
 
-  procedure append(variable arr : inout integer_array_t; value : integer);
-  procedure reshape(variable arr : inout integer_array_t; length : integer);
-  procedure reshape(variable arr : inout integer_array_t; width, height : integer);
-  procedure reshape(variable arr : inout integer_array_t; width, height, depth : integer);
-  procedure save_csv(arr : integer_array_t; file_name : string);
-  procedure save_raw(arr : integer_array_t; file_name : string);
+  impure function
+  width(
+    arr : integer_array_t
+  ) return integer;
+
+  impure function
+  height(
+    arr : integer_array_t
+  ) return integer;
+
+  impure function
+  depth(
+    arr : integer_array_t
+  ) return integer;
+
+  impure function
+  bit_width(
+    arr : integer_array_t
+  ) return integer;
+
+  impure function
+  is_signed(
+    arr : integer_array_t
+  ) return boolean;
+
+  impure function
+  bytes_per_word(
+    arr : integer_array_t
+  ) return integer;
+
+  impure function
+  lower_limit(
+    arr : integer_array_t
+  ) return integer;
+
+  impure function
+  upper_limit(
+    arr : integer_array_t
+  ) return integer;
+
+  impure function
+  get(
+    arr : integer_array_t;
+    idx : integer
+  ) return integer;
+
+  impure function
+  get(
+    arr : integer_array_t;
+    x,y : integer
+  ) return integer;
+
+  impure function
+  get(
+    arr   : integer_array_t;
+    x,y,z : integer
+  ) return integer;
+
+  procedure
+  set(
+    arr   : integer_array_t;
+    idx   : integer;
+    value : integer
+  );
+
+  procedure
+  set(
+    arr   : integer_array_t;
+    x,y   : integer;
+    value : integer
+  );
+
+  procedure
+  set(
+    arr   : integer_array_t;
+    x,y,z : integer;
+    value : integer
+  );
+
+  procedure
+  append(
+    variable arr : inout integer_array_t;
+    value : integer
+  );
+
+  procedure
+  reshape(
+    variable arr : inout integer_array_t;
+    length : integer
+  );
+
+  procedure
+  reshape(
+    variable arr  : inout integer_array_t;
+    width, height : integer
+  );
+
+  procedure
+  reshape(
+    variable arr : inout integer_array_t;
+    width, height, depth : integer
+  );
+
+  procedure
+  save_csv(
+    arr       : integer_array_t;
+    file_name : string
+  );
+
+  procedure
+  save_raw(
+    arr       : integer_array_t;
+    file_name : string
+  );
 end package;

--- a/vunit/vhdl/data_types/src/integer_array_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_array_pkg.vhd
@@ -35,23 +35,20 @@ package integer_array_pkg is
 
   type integer_array_vec_t is array (natural range <>) of integer_array_t;
 
-  impure function
-  new_1d(
+  impure function new_1d (
     length    : integer := 0;
     bit_width : natural := 32;
     is_signed : boolean := true
   ) return integer_array_t;
 
-  impure function
-  new_2d(
+  impure function new_2d (
     width     : integer := 0;
     height    : integer := 0;
     bit_width : natural := 32;
     is_signed : boolean := true
   ) return integer_array_t;
 
-  impure function
-  new_3d(
+  impure function new_3d (
     width     : integer := 0;
     height    : integer := 0;
     depth     : integer := 0;
@@ -59,151 +56,125 @@ package integer_array_pkg is
     is_signed : boolean := true
   ) return integer_array_t;
 
-  impure function
-  copy(
+  impure function copy (
     arr : integer_array_t
   ) return integer_array_t;
 
-  impure function
-  load_csv(
+  impure function load_csv (
     file_name : string;
     bit_width : natural := 32;
     is_signed : boolean := true
   ) return integer_array_t;
 
-  impure function
-  load_raw(
+  impure function load_raw (
     file_name : string;
     bit_width : natural := 32;
     is_signed : boolean := true
   ) return integer_array_t;
 
-  procedure
-  deallocate(
+  procedure deallocate (
     variable arr : inout integer_array_t
   );
 
-  impure function
-  is_null(
+  impure function is_null (
     arr : integer_array_t
   ) return boolean;
 
-  impure function
-  length(
+  impure function length (
     arr : integer_array_t
   ) return integer;
 
-  impure function
-  width(
+  impure function width (
     arr : integer_array_t
   ) return integer;
 
-  impure function
-  height(
+  impure function height (
     arr : integer_array_t
   ) return integer;
 
-  impure function
-  depth(
+  impure function depth (
     arr : integer_array_t
   ) return integer;
 
-  impure function
-  bit_width(
+  impure function bit_width (
     arr : integer_array_t
   ) return integer;
 
-  impure function
-  is_signed(
+  impure function is_signed (
     arr : integer_array_t
   ) return boolean;
 
-  impure function
-  bytes_per_word(
+  impure function bytes_per_word (
     arr : integer_array_t
   ) return integer;
 
-  impure function
-  lower_limit(
+  impure function lower_limit (
     arr : integer_array_t
   ) return integer;
 
-  impure function
-  upper_limit(
+  impure function upper_limit (
     arr : integer_array_t
   ) return integer;
 
-  impure function
-  get(
+  impure function get (
     arr : integer_array_t;
     idx : integer
   ) return integer;
 
-  impure function
-  get(
+  impure function get (
     arr : integer_array_t;
     x,y : integer
   ) return integer;
 
-  impure function
-  get(
+  impure function get (
     arr   : integer_array_t;
     x,y,z : integer
   ) return integer;
 
-  procedure
-  set(
+  procedure set (
     arr   : integer_array_t;
     idx   : integer;
     value : integer
   );
 
-  procedure
-  set(
+  procedure set (
     arr   : integer_array_t;
     x,y   : integer;
     value : integer
   );
 
-  procedure
-  set(
+  procedure set (
     arr   : integer_array_t;
     x,y,z : integer;
     value : integer
   );
 
-  procedure
-  append(
+  procedure append (
     variable arr : inout integer_array_t;
-    value : integer
+    value        : integer
   );
 
-  procedure
-  reshape(
+  procedure reshape (
     variable arr : inout integer_array_t;
-    length : integer
+    length       : integer
   );
 
-  procedure
-  reshape(
+  procedure reshape (
     variable arr  : inout integer_array_t;
     width, height : integer
   );
 
-  procedure
-  reshape(
-    variable arr : inout integer_array_t;
+  procedure reshape (
+    variable arr         : inout integer_array_t;
     width, height, depth : integer
   );
 
-  procedure
-  save_csv(
+  procedure save_csv (
     arr       : integer_array_t;
     file_name : string
   );
 
-  procedure
-  save_raw(
+  procedure save_raw (
     arr       : integer_array_t;
     file_name : string
   );

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -6,44 +6,37 @@
 
 package body integer_vector_ptr_pkg is
  type integer_vector_ptr_storage_t is protected
-    impure function
-    new_integer_vector_ptr(
+    impure function new_integer_vector_ptr (
       len   : natural := 0;
       value : val_t := 0
     ) return natural;
 
-    procedure
-    deallocate(
+    procedure deallocate (
       ref : natural
     );
 
-    impure function
-    length(
+    impure function length (
       ref : natural
     ) return integer;
 
-    procedure
-    set(
+    procedure set (
       ref   : natural;
       index : natural;
       value : val_t
     );
 
-    impure function
-    get(
+    impure function get (
       ref   : natural;
       index : natural
     ) return val_t;
 
-    procedure
-    reallocate(
+    procedure reallocate (
       ref   : natural;
       len   : natural;
       value : val_t := 0
     );
 
-    procedure
-    resize(
+    procedure resize (
       ref   : natural;
       len   : natural;
       drop  : natural := 0;
@@ -55,15 +48,13 @@ package body integer_vector_ptr_pkg is
     variable current_index : integer := 0;
     variable ptrs : vava_t := null;
 
-    impure function
-    new_integer_vector_ptr(
+    impure function new_integer_vector_ptr (
       len   : natural := 0;
       value : val_t := 0
     ) return natural is
       variable old_ptrs : vava_t;
       variable retval : ptr_t := (ref => current_index);
     begin
-
       if ptrs = null then
         ptrs := new vav_t'(0 => null);
       elsif ptrs'length <= current_index then
@@ -76,29 +67,25 @@ package body integer_vector_ptr_pkg is
         end loop;
         deallocate(old_ptrs);
       end if;
-
       ptrs(current_index) := new integer_vector_t'(0 to len-1 => value);
       current_index := current_index + 1;
       return retval.ref;
     end;
 
-    procedure
-    deallocate(
+    procedure deallocate (
       ref : natural
     ) is begin
       deallocate(ptrs(ref));
       ptrs(ref) := null;
     end;
 
-    impure function
-    length(
+    impure function length (
       ref : natural
     ) return integer is begin
       return ptrs(ref)'length;
     end;
 
-    procedure
-    set(
+    procedure set (
       ref   : natural;
       index : natural;
       value : val_t
@@ -106,16 +93,14 @@ package body integer_vector_ptr_pkg is
       ptrs(ref)(index) := value;
     end;
 
-    impure function
-    get(
+    impure function get (
       ref   : natural;
       index : natural
     ) return val_t is begin
       return ptrs(ref)(index);
     end;
 
-    procedure
-    reallocate(
+    procedure reallocate (
       ref   : natural;
       len   : natural;
       value : val_t := 0
@@ -124,8 +109,7 @@ package body integer_vector_ptr_pkg is
       ptrs(ref) := new integer_vector_t'(0 to len - 1 => value);
     end;
 
-    procedure
-    resize(
+    procedure resize (
       ref   : natural;
       len   : natural;
       drop  : natural := 0;
@@ -150,45 +134,39 @@ package body integer_vector_ptr_pkg is
 
   shared variable integer_vector_ptr_storage : integer_vector_ptr_storage_t;
 
-  function
-  to_integer(
+  function to_integer (
     value : ptr_t
   ) return integer is begin
     return value.ref;
   end;
 
-  impure function
-  to_integer_vector_ptr(
+  impure function to_integer_vector_ptr (
     value : integer
   ) return ptr_t is begin
     -- @TODO maybe assert that the ref is valid
     return (ref => value);
   end;
 
-  impure function
-  new_integer_vector_ptr(
+  impure function new_integer_vector_ptr (
     len   : natural := 0;
     value : val_t := 0
   ) return ptr_t is begin
     return (ref => integer_vector_ptr_storage.new_integer_vector_ptr(len, value));
   end;
 
-  procedure
-  deallocate(
+  procedure deallocate (
     ptr : ptr_t
   ) is begin
     integer_vector_ptr_storage.deallocate(ptr.ref);
   end;
 
-  impure function
-  length(
+  impure function length (
     ptr : ptr_t
   ) return integer is begin
     return integer_vector_ptr_storage.length(ptr.ref);
   end;
 
-  procedure
-  set(
+  procedure set (
     ptr   : ptr_t;
     index : natural;
     value : val_t
@@ -196,16 +174,14 @@ package body integer_vector_ptr_pkg is
     integer_vector_ptr_storage.set(ptr.ref, index, value);
   end;
 
-  impure function
-  get(
+  impure function get (
     ptr   : ptr_t;
     index : natural
   ) return val_t is begin
     return integer_vector_ptr_storage.get(ptr.ref, index);
   end;
 
-  procedure
-  reallocate(
+  procedure reallocate (
     ptr   : ptr_t;
     len   : natural;
     value : val_t := 0
@@ -213,8 +189,7 @@ package body integer_vector_ptr_pkg is
     integer_vector_ptr_storage.reallocate(ptr.ref, len, value);
   end;
 
-  procedure
-  resize(
+  procedure resize (
     ptr   : ptr_t;
     len   : natural;
     drop  : natural := 0;
@@ -223,15 +198,13 @@ package body integer_vector_ptr_pkg is
     integer_vector_ptr_storage.resize(ptr.ref, len, drop, value);
   end;
 
-  function
-  encode(
+  function encode (
     data : ptr_t
   ) return string is begin
     return encode(data.ref);
   end;
 
-  function
-  decode(
+  function decode (
     code : string
   ) return ptr_t is
     variable ret_val : ptr_t;
@@ -241,8 +214,7 @@ package body integer_vector_ptr_pkg is
     return ret_val;
   end;
 
-  procedure
-  decode(
+  procedure decode (
     constant code   : string;
     variable index  : inout positive;
     variable result : out ptr_t

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -10,41 +10,41 @@ package body integer_vector_ptr_pkg is
     new_integer_vector_ptr(
       length : natural := 0;
       value  : val_t := 0
-    ) return ptr_t;
+    ) return natural;
 
     procedure
     deallocate(
-      ptr : ptr_t
+      ref : natural
     );
 
     impure function
     length(
-      ptr : ptr_t
+      ref : natural
     ) return integer;
 
     procedure
     set(
-      ptr   : ptr_t;
+      ref   : natural;
       index : integer;
       value : val_t
     );
 
     impure function
     get(
-      ptr   : ptr_t;
+      ref   : natural;
       index : integer
     ) return val_t;
 
     procedure
     reallocate(
-      ptr    : ptr_t;
+      ref    : natural;
       length : natural;
       value  : val_t := 0
     );
 
     procedure
     resize(
-      ptr    : ptr_t;
+      ref    : natural;
       length : natural;
       drop   : natural := 0;
       value  : val_t := 0
@@ -59,7 +59,7 @@ package body integer_vector_ptr_pkg is
     new_integer_vector_ptr(
       length : natural := 0;
       value  : val_t := 0
-    ) return ptr_t is
+    ) return natural is
       variable old_ptrs : vava_t;
       variable retval : ptr_t := (index => current_index);
     begin
@@ -79,54 +79,54 @@ package body integer_vector_ptr_pkg is
 
       ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
       current_index := current_index + 1;
-      return retval;
+      return retval.index;
     end;
 
     procedure
     deallocate(
-      ptr : ptr_t
+      ref : natural
     ) is begin
-      deallocate(ptrs(ptr.index));
-      ptrs(ptr.index) := null;
+      deallocate(ptrs(ref));
+      ptrs(ref) := null;
     end;
 
     impure function
     length(
-      ptr : ptr_t
+      ref : natural
     ) return integer is begin
-      return ptrs(ptr.index)'length;
+      return ptrs(ref)'length;
     end;
 
     procedure
     set(
-      ptr   : ptr_t;
+      ref   : natural;
       index : integer;
       value : val_t
     ) is begin
-      ptrs(ptr.index)(index) := value;
+      ptrs(ref)(index) := value;
     end;
 
     impure function
     get(
-      ptr   : ptr_t;
+      ref   : natural;
       index : integer
     ) return val_t is begin
-      return ptrs(ptr.index)(index);
+      return ptrs(ref)(index);
     end;
 
     procedure
     reallocate(
-      ptr    : ptr_t;
+      ref    : natural;
       length : natural;
       value  : val_t := 0
     ) is begin
-      deallocate(ptrs(ptr.index));
-      ptrs(ptr.index) := new integer_vector_t'(0 to length - 1 => value);
+      deallocate(ptrs(ref));
+      ptrs(ref) := new integer_vector_t'(0 to length - 1 => value);
     end;
 
     procedure
     resize(
-      ptr    : ptr_t;
+      ref    : natural;
       length : natural;
       drop   : natural := 0;
       value  : val_t := 0
@@ -135,14 +135,14 @@ package body integer_vector_ptr_pkg is
       variable min_length : natural := length;
     begin
       new_ptr := new integer_vector_t'(0 to length - 1 => value);
-      old_ptr := ptrs(ptr.index);
+      old_ptr := ptrs(ref);
       if min_length > old_ptr'length - drop then
         min_length := old_ptr'length - drop;
       end if;
       for i in 0 to min_length-1 loop
         new_ptr(i) := old_ptr(drop + i);
       end loop;
-      ptrs(ptr.index) := new_ptr;
+      ptrs(ref) := new_ptr;
       deallocate(old_ptr);
     end;
 
@@ -170,21 +170,21 @@ package body integer_vector_ptr_pkg is
     length : natural := 0;
     value  : val_t := 0
   ) return ptr_t is begin
-    return integer_vector_ptr_storage.new_integer_vector_ptr(length, value);
+    return (index => integer_vector_ptr_storage.new_integer_vector_ptr(length, value));
   end;
 
   procedure
   deallocate(
     ptr : ptr_t
   ) is begin
-    integer_vector_ptr_storage.deallocate(ptr);
+    integer_vector_ptr_storage.deallocate(ptr.index);
   end;
 
   impure function
   length(
     ptr : ptr_t
   ) return integer is begin
-    return integer_vector_ptr_storage.length(ptr);
+    return integer_vector_ptr_storage.length(ptr.index);
   end;
 
   procedure
@@ -193,7 +193,7 @@ package body integer_vector_ptr_pkg is
     index : integer;
     value : val_t
   ) is begin
-    integer_vector_ptr_storage.set(ptr, index, value);
+    integer_vector_ptr_storage.set(ptr.index, index, value);
   end;
 
   impure function
@@ -201,7 +201,7 @@ package body integer_vector_ptr_pkg is
     ptr   : ptr_t;
     index : integer
   ) return val_t is begin
-    return integer_vector_ptr_storage.get(ptr, index);
+    return integer_vector_ptr_storage.get(ptr.index, index);
   end;
 
   procedure
@@ -210,7 +210,7 @@ package body integer_vector_ptr_pkg is
     length : natural;
     value  : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.reallocate(ptr, length, value);
+    integer_vector_ptr_storage.reallocate(ptr.index, length, value);
   end;
 
   procedure
@@ -220,7 +220,7 @@ package body integer_vector_ptr_pkg is
     drop   : natural := 0;
     value  : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.resize(ptr, length, drop, value);
+    integer_vector_ptr_storage.resize(ptr.index, length, drop, value);
   end;
 
   function

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -25,14 +25,14 @@ package body integer_vector_ptr_pkg is
     procedure
     set(
       ref   : natural;
-      index : integer;
+      index : natural;
       value : val_t
     );
 
     impure function
     get(
       ref   : natural;
-      index : integer
+      index : natural
     ) return val_t;
 
     procedure
@@ -100,7 +100,7 @@ package body integer_vector_ptr_pkg is
     procedure
     set(
       ref   : natural;
-      index : integer;
+      index : natural;
       value : val_t
     ) is begin
       ptrs(ref)(index) := value;
@@ -109,7 +109,7 @@ package body integer_vector_ptr_pkg is
     impure function
     get(
       ref   : natural;
-      index : integer
+      index : natural
     ) return val_t is begin
       return ptrs(ref)(index);
     end;
@@ -190,7 +190,7 @@ package body integer_vector_ptr_pkg is
   procedure
   set(
     ptr   : ptr_t;
-    index : integer;
+    index : natural;
     value : val_t
   ) is begin
     integer_vector_ptr_storage.set(ptr.ref, index, value);
@@ -199,7 +199,7 @@ package body integer_vector_ptr_pkg is
   impure function
   get(
     ptr   : ptr_t;
-    index : integer
+    index : natural
   ) return val_t is begin
     return integer_vector_ptr_storage.get(ptr.ref, index);
   end;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -61,7 +61,7 @@ package body integer_vector_ptr_pkg is
       value  : val_t := 0
     ) return natural is
       variable old_ptrs : vava_t;
-      variable retval : ptr_t := (index => current_index);
+      variable retval : ptr_t := (ref => current_index);
     begin
 
       if ptrs = null then
@@ -79,7 +79,7 @@ package body integer_vector_ptr_pkg is
 
       ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
       current_index := current_index + 1;
-      return retval.index;
+      return retval.ref;
     end;
 
     procedure
@@ -154,15 +154,15 @@ package body integer_vector_ptr_pkg is
   to_integer(
     value : ptr_t
   ) return integer is begin
-    return value.index;
+    return value.ref;
   end;
 
   impure function
   to_integer_vector_ptr(
     value : integer
   ) return ptr_t is begin
-    -- @TODO maybe assert that the index is valid
-    return (index => value);
+    -- @TODO maybe assert that the ref is valid
+    return (ref => value);
   end;
 
   impure function
@@ -170,21 +170,21 @@ package body integer_vector_ptr_pkg is
     length : natural := 0;
     value  : val_t := 0
   ) return ptr_t is begin
-    return (index => integer_vector_ptr_storage.new_integer_vector_ptr(length, value));
+    return (ref => integer_vector_ptr_storage.new_integer_vector_ptr(length, value));
   end;
 
   procedure
   deallocate(
     ptr : ptr_t
   ) is begin
-    integer_vector_ptr_storage.deallocate(ptr.index);
+    integer_vector_ptr_storage.deallocate(ptr.ref);
   end;
 
   impure function
   length(
     ptr : ptr_t
   ) return integer is begin
-    return integer_vector_ptr_storage.length(ptr.index);
+    return integer_vector_ptr_storage.length(ptr.ref);
   end;
 
   procedure
@@ -193,7 +193,7 @@ package body integer_vector_ptr_pkg is
     index : integer;
     value : val_t
   ) is begin
-    integer_vector_ptr_storage.set(ptr.index, index, value);
+    integer_vector_ptr_storage.set(ptr.ref, index, value);
   end;
 
   impure function
@@ -201,7 +201,7 @@ package body integer_vector_ptr_pkg is
     ptr   : ptr_t;
     index : integer
   ) return val_t is begin
-    return integer_vector_ptr_storage.get(ptr.index, index);
+    return integer_vector_ptr_storage.get(ptr.ref, index);
   end;
 
   procedure
@@ -210,7 +210,7 @@ package body integer_vector_ptr_pkg is
     length : natural;
     value  : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.reallocate(ptr.index, length, value);
+    integer_vector_ptr_storage.reallocate(ptr.ref, length, value);
   end;
 
   procedure
@@ -220,14 +220,14 @@ package body integer_vector_ptr_pkg is
     drop   : natural := 0;
     value  : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.resize(ptr.index, length, drop, value);
+    integer_vector_ptr_storage.resize(ptr.ref, length, drop, value);
   end;
 
   function
   encode(
     data : ptr_t
   ) return string is begin
-    return encode(data.index);
+    return encode(data.ref);
   end;
 
   function
@@ -247,7 +247,7 @@ package body integer_vector_ptr_pkg is
     variable index  : inout positive;
     variable result : out ptr_t
   ) is begin
-    decode(code, index, result.index);
+    decode(code, index, result.ref);
   end;
 
 end package body;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -5,11 +5,6 @@
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 package body integer_vector_ptr_pkg is
-  type integer_vector_t is array (natural range <>) of integer;
-  type integer_vector_access_t is access integer_vector_t;
-  type integer_vector_access_vector_t is array (natural range <>) of integer_vector_access_t;
-  type integer_vector_access_vector_access_t is access integer_vector_access_vector_t;
-
  type integer_vector_ptr_storage_t is protected
     impure function
     new_integer_vector_ptr(
@@ -82,7 +77,7 @@ package body integer_vector_ptr_pkg is
         deallocate(old_ptrs);
       end if;
 
-      ptrs(current_index) := new integer_vector'(0 to length-1 => value);
+      ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
       current_index := current_index + 1;
       return retval;
     end;
@@ -126,7 +121,7 @@ package body integer_vector_ptr_pkg is
       value  : val_t := 0
     ) is begin
       deallocate(ptrs(ptr.index));
-      ptrs(ptr.index) := new integer_vector'(0 to length - 1 => value);
+      ptrs(ptr.index) := new integer_vector_t'(0 to length - 1 => value);
     end;
 
     procedure
@@ -139,7 +134,7 @@ package body integer_vector_ptr_pkg is
       variable old_ptr, new_ptr : integer_vector_access_t;
       variable min_length : natural := length;
     begin
-      new_ptr := new integer_vector'(0 to length - 1 => value);
+      new_ptr := new integer_vector_t'(0 to length - 1 => value);
       old_ptr := ptrs(ptr.index);
       if min_length > old_ptr'length - drop then
         min_length := old_ptr'length - drop;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -8,8 +8,8 @@ package body integer_vector_ptr_pkg is
  type integer_vector_ptr_storage_t is protected
     impure function
     new_integer_vector_ptr(
-      length : natural := 0;
-      value  : val_t := 0
+      len   : natural := 0;
+      value : val_t := 0
     ) return natural;
 
     procedure
@@ -37,17 +37,17 @@ package body integer_vector_ptr_pkg is
 
     procedure
     reallocate(
-      ref    : natural;
-      length : natural;
-      value  : val_t := 0
+      ref   : natural;
+      len   : natural;
+      value : val_t := 0
     );
 
     procedure
     resize(
-      ref    : natural;
-      length : natural;
-      drop   : natural := 0;
-      value  : val_t := 0
+      ref   : natural;
+      len   : natural;
+      drop  : natural := 0;
+      value : val_t := 0
     );
   end protected;
 
@@ -57,8 +57,8 @@ package body integer_vector_ptr_pkg is
 
     impure function
     new_integer_vector_ptr(
-      length : natural := 0;
-      value  : val_t := 0
+      len   : natural := 0;
+      value : val_t := 0
     ) return natural is
       variable old_ptrs : vava_t;
       variable retval : ptr_t := (ref => current_index);
@@ -77,7 +77,7 @@ package body integer_vector_ptr_pkg is
         deallocate(old_ptrs);
       end if;
 
-      ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
+      ptrs(current_index) := new integer_vector_t'(0 to len-1 => value);
       current_index := current_index + 1;
       return retval.ref;
     end;
@@ -116,30 +116,30 @@ package body integer_vector_ptr_pkg is
 
     procedure
     reallocate(
-      ref    : natural;
-      length : natural;
-      value  : val_t := 0
+      ref   : natural;
+      len   : natural;
+      value : val_t := 0
     ) is begin
       deallocate(ptrs(ref));
-      ptrs(ref) := new integer_vector_t'(0 to length - 1 => value);
+      ptrs(ref) := new integer_vector_t'(0 to len - 1 => value);
     end;
 
     procedure
     resize(
-      ref    : natural;
-      length : natural;
-      drop   : natural := 0;
-      value  : val_t := 0
+      ref   : natural;
+      len   : natural;
+      drop  : natural := 0;
+      value : val_t := 0
     ) is
       variable old_ptr, new_ptr : integer_vector_access_t;
-      variable min_length : natural := length;
+      variable min_len : natural := len;
     begin
-      new_ptr := new integer_vector_t'(0 to length - 1 => value);
+      new_ptr := new integer_vector_t'(0 to len - 1 => value);
       old_ptr := ptrs(ref);
-      if min_length > old_ptr'length - drop then
-        min_length := old_ptr'length - drop;
+      if min_len > old_ptr'length - drop then
+        min_len := old_ptr'length - drop;
       end if;
-      for i in 0 to min_length-1 loop
+      for i in 0 to min_len-1 loop
         new_ptr(i) := old_ptr(drop + i);
       end loop;
       ptrs(ref) := new_ptr;
@@ -167,10 +167,10 @@ package body integer_vector_ptr_pkg is
 
   impure function
   new_integer_vector_ptr(
-    length : natural := 0;
-    value  : val_t := 0
+    len   : natural := 0;
+    value : val_t := 0
   ) return ptr_t is begin
-    return (ref => integer_vector_ptr_storage.new_integer_vector_ptr(length, value));
+    return (ref => integer_vector_ptr_storage.new_integer_vector_ptr(len, value));
   end;
 
   procedure
@@ -206,21 +206,21 @@ package body integer_vector_ptr_pkg is
 
   procedure
   reallocate(
-    ptr    : ptr_t;
-    length : natural;
-    value  : val_t := 0
+    ptr   : ptr_t;
+    len   : natural;
+    value : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.reallocate(ptr.ref, length, value);
+    integer_vector_ptr_storage.reallocate(ptr.ref, len, value);
   end;
 
   procedure
   resize(
-    ptr    : ptr_t;
-    length : natural;
-    drop   : natural := 0;
-    value  : val_t := 0
+    ptr   : ptr_t;
+    len   : natural;
+    drop  : natural := 0;
+    value : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.resize(ptr.ref, length, drop, value);
+    integer_vector_ptr_storage.resize(ptr.ref, len, drop, value);
   end;
 
   function

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -11,20 +11,60 @@ package body integer_vector_ptr_pkg is
   type integer_vector_access_vector_access_t is access integer_vector_access_vector_t;
 
  type integer_vector_ptr_storage_t is protected
-    impure function new_integer_vector_ptr(length : natural := 0; value : integer := 0) return integer_vector_ptr_t;
-    procedure deallocate(ptr : integer_vector_ptr_t);
-    impure function length(ptr : integer_vector_ptr_t) return integer;
-    procedure set(ptr : integer_vector_ptr_t; index : integer; value : integer);
-    impure function get(ptr : integer_vector_ptr_t; index : integer) return integer;
-    procedure reallocate(ptr : integer_vector_ptr_t; length : natural; value : integer := 0);
-    procedure resize(ptr : integer_vector_ptr_t; length : natural; drop : natural := 0; value : integer := 0);
+    impure function
+    new_integer_vector_ptr(
+      length : natural := 0;
+      value  : integer := 0
+    ) return integer_vector_ptr_t;
+
+    procedure
+    deallocate(
+      ptr : integer_vector_ptr_t
+    );
+
+    impure function
+    length(
+      ptr : integer_vector_ptr_t
+    ) return integer;
+
+    procedure
+    set(
+      ptr   : integer_vector_ptr_t;
+      index : integer;
+      value : integer
+    );
+
+    impure function
+    get(
+      ptr   : integer_vector_ptr_t;
+      index : integer
+    ) return integer;
+
+    procedure
+    reallocate(
+      ptr    : integer_vector_ptr_t;
+      length : natural;
+      value  : integer := 0
+    );
+
+    procedure
+    resize(
+      ptr    : integer_vector_ptr_t;
+      length : natural;
+      drop   : natural := 0;
+      value  : integer := 0
+    );
   end protected;
 
   type integer_vector_ptr_storage_t is protected body
     variable current_index : integer := 0;
     variable ptrs : integer_vector_access_vector_access_t := null;
 
-    impure function new_integer_vector_ptr(length : natural := 0; value : integer := 0) return integer_vector_ptr_t is
+    impure function
+    new_integer_vector_ptr(
+      length : natural := 0;
+      value  : integer := 0
+    ) return integer_vector_ptr_t is
       variable old_ptrs : integer_vector_access_vector_access_t;
       variable retval : integer_vector_ptr_t := (index => current_index);
     begin
@@ -45,36 +85,57 @@ package body integer_vector_ptr_pkg is
       ptrs(current_index) := new integer_vector'(0 to length-1 => value);
       current_index := current_index + 1;
       return retval;
-    end function;
+    end;
 
-    procedure deallocate(ptr : integer_vector_ptr_t) is
-    begin
+    procedure
+    deallocate(
+      ptr : integer_vector_ptr_t
+    ) is begin
       deallocate(ptrs(ptr.index));
       ptrs(ptr.index) := null;
-    end procedure;
+    end;
 
-    impure function length(ptr : integer_vector_ptr_t) return integer is
-    begin
+    impure function
+    length(
+      ptr : integer_vector_ptr_t
+    ) return integer is begin
       return ptrs(ptr.index)'length;
-    end function;
+    end;
 
-    procedure set(ptr : integer_vector_ptr_t; index : integer; value : integer) is
-    begin
+    procedure
+    set(
+      ptr   : integer_vector_ptr_t;
+      index : integer;
+      value : integer
+    ) is begin
       ptrs(ptr.index)(index) := value;
-    end procedure;
+    end;
 
-    impure function get(ptr : integer_vector_ptr_t; index : integer) return integer is
-    begin
+    impure function
+    get(
+      ptr   : integer_vector_ptr_t;
+      index : integer
+    ) return integer is begin
       return ptrs(ptr.index)(index);
-    end function;
+    end;
 
-    procedure reallocate(ptr : integer_vector_ptr_t; length : natural; value : integer := 0) is
-    begin
+    procedure
+    reallocate(
+      ptr    : integer_vector_ptr_t;
+      length : natural;
+      value  : integer := 0
+    ) is begin
       deallocate(ptrs(ptr.index));
       ptrs(ptr.index) := new integer_vector'(0 to length - 1 => value);
-    end procedure;
+    end;
 
-    procedure resize(ptr : integer_vector_ptr_t; length : natural; drop : natural := 0; value : integer := 0) is
+    procedure
+    resize(
+      ptr    : integer_vector_ptr_t;
+      length : natural;
+      drop   : natural := 0;
+      value  : integer := 0
+    ) is
       variable old_ptr, new_ptr : integer_vector_access_t;
       variable min_length : natural := length;
     begin
@@ -90,77 +151,109 @@ package body integer_vector_ptr_pkg is
       end loop;
       ptrs(ptr.index) := new_ptr;
       deallocate(old_ptr);
-    end procedure;
+    end;
 
   end protected body;
 
   shared variable integer_vector_ptr_storage : integer_vector_ptr_storage_t;
 
-  function to_integer(value : integer_vector_ptr_t) return integer is
-  begin
+  function
+  to_integer(
+    value : integer_vector_ptr_t
+  ) return integer is begin
     return value.index;
-  end function;
+  end;
 
-  impure function to_integer_vector_ptr(value : integer) return integer_vector_ptr_t is
-  begin
+  impure function
+  to_integer_vector_ptr(
+    value : integer
+  ) return integer_vector_ptr_t is begin
     -- @TODO maybe assert that the index is valid
     return (index => value);
-  end function;
+  end;
 
-  impure function new_integer_vector_ptr(length : natural := 0; value : integer := 0) return integer_vector_ptr_t is
-  begin
+  impure function
+  new_integer_vector_ptr(
+    length : natural := 0;
+    value  : integer := 0
+  ) return integer_vector_ptr_t is begin
     return integer_vector_ptr_storage.new_integer_vector_ptr(length, value);
-  end function;
+  end;
 
-  procedure deallocate(ptr : integer_vector_ptr_t) is
-  begin
+  procedure
+  deallocate(
+    ptr : integer_vector_ptr_t
+  ) is begin
     integer_vector_ptr_storage.deallocate(ptr);
-  end procedure;
+  end;
 
-  impure function length(ptr : integer_vector_ptr_t) return integer is
-  begin
+  impure function
+  length(
+    ptr : integer_vector_ptr_t
+  ) return integer is begin
     return integer_vector_ptr_storage.length(ptr);
-  end function;
+  end;
 
-  procedure set(ptr : integer_vector_ptr_t; index : integer; value : integer) is
-  begin
+  procedure
+  set(
+    ptr   : integer_vector_ptr_t;
+    index : integer;
+    value : integer
+  ) is begin
     integer_vector_ptr_storage.set(ptr, index, value);
-  end procedure;
+  end;
 
-  impure function get(ptr : integer_vector_ptr_t; index : integer) return integer is
-  begin
+  impure function
+  get(
+    ptr   : integer_vector_ptr_t;
+    index : integer
+  ) return integer is begin
     return integer_vector_ptr_storage.get(ptr, index);
-  end function;
+  end;
 
-  procedure reallocate(ptr : integer_vector_ptr_t; length : natural; value : integer := 0) is
-  begin
+  procedure
+  reallocate(
+    ptr    : integer_vector_ptr_t;
+    length : natural;
+    value  : integer := 0
+  ) is begin
     integer_vector_ptr_storage.reallocate(ptr, length, value);
-  end procedure;
+  end;
 
-  procedure resize(ptr : integer_vector_ptr_t; length : natural; drop : natural := 0; value : integer := 0) is
-  begin
+  procedure
+  resize(
+    ptr    : integer_vector_ptr_t;
+    length : natural;
+    drop   : natural := 0;
+    value  : integer := 0
+  ) is begin
     integer_vector_ptr_storage.resize(ptr, length, drop, value);
-  end procedure;
+  end;
 
-  function encode(data : integer_vector_ptr_t) return string is
-  begin
+  function
+  encode(
+    data : integer_vector_ptr_t
+  ) return string is begin
     return encode(data.index);
   end;
 
-  function decode(code : string) return integer_vector_ptr_t is
+  function
+  decode(
+    code : string
+  ) return integer_vector_ptr_t is
     variable ret_val : integer_vector_ptr_t;
-    variable index : positive := code'left;
+    variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
-
     return ret_val;
   end;
 
-  procedure decode (
-    constant code : string;
-    variable index : inout positive;
-    variable result : out integer_vector_ptr_t) is
-  begin
+  procedure
+  decode(
+    constant code   : string;
+    variable index  : inout positive;
+    variable result : out integer_vector_ptr_t
+  ) is begin
     decode(code, index, result.index);
   end;
 

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -5,8 +5,8 @@
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 package body integer_vector_ptr_pkg is
-  type integer_vector is array (natural range <>) of integer;
-  type integer_vector_access_t is access integer_vector;
+  type integer_vector_t is array (natural range <>) of integer;
+  type integer_vector_access_t is access integer_vector_t;
   type integer_vector_access_vector_t is array (natural range <>) of integer_vector_access_t;
   type integer_vector_access_vector_access_t is access integer_vector_access_vector_t;
 
@@ -14,68 +14,68 @@ package body integer_vector_ptr_pkg is
     impure function
     new_integer_vector_ptr(
       length : natural := 0;
-      value  : integer := 0
-    ) return integer_vector_ptr_t;
+      value  : val_t := 0
+    ) return ptr_t;
 
     procedure
     deallocate(
-      ptr : integer_vector_ptr_t
+      ptr : ptr_t
     );
 
     impure function
     length(
-      ptr : integer_vector_ptr_t
+      ptr : ptr_t
     ) return integer;
 
     procedure
     set(
-      ptr   : integer_vector_ptr_t;
+      ptr   : ptr_t;
       index : integer;
-      value : integer
+      value : val_t
     );
 
     impure function
     get(
-      ptr   : integer_vector_ptr_t;
+      ptr   : ptr_t;
       index : integer
-    ) return integer;
+    ) return val_t;
 
     procedure
     reallocate(
-      ptr    : integer_vector_ptr_t;
+      ptr    : ptr_t;
       length : natural;
-      value  : integer := 0
+      value  : val_t := 0
     );
 
     procedure
     resize(
-      ptr    : integer_vector_ptr_t;
+      ptr    : ptr_t;
       length : natural;
       drop   : natural := 0;
-      value  : integer := 0
+      value  : val_t := 0
     );
   end protected;
 
   type integer_vector_ptr_storage_t is protected body
     variable current_index : integer := 0;
-    variable ptrs : integer_vector_access_vector_access_t := null;
+    variable ptrs : vava_t := null;
 
     impure function
     new_integer_vector_ptr(
       length : natural := 0;
-      value  : integer := 0
-    ) return integer_vector_ptr_t is
-      variable old_ptrs : integer_vector_access_vector_access_t;
-      variable retval : integer_vector_ptr_t := (index => current_index);
+      value  : val_t := 0
+    ) return ptr_t is
+      variable old_ptrs : vava_t;
+      variable retval : ptr_t := (index => current_index);
     begin
 
       if ptrs = null then
-        ptrs := new integer_vector_access_vector_t'(0 => null);
+        ptrs := new vav_t'(0 => null);
       elsif ptrs'length <= current_index then
         -- Reallocate ptr pointers to larger ptr
         -- Use more size to trade size for speed
         old_ptrs := ptrs;
-        ptrs := new integer_vector_access_vector_t'(0 to ptrs'length + 2**16 => null);
+        ptrs := new vav_t'(0 to ptrs'length + 2**16 => null);
         for i in old_ptrs'range loop
           ptrs(i) := old_ptrs(i);
         end loop;
@@ -89,7 +89,7 @@ package body integer_vector_ptr_pkg is
 
     procedure
     deallocate(
-      ptr : integer_vector_ptr_t
+      ptr : ptr_t
     ) is begin
       deallocate(ptrs(ptr.index));
       ptrs(ptr.index) := null;
@@ -97,33 +97,33 @@ package body integer_vector_ptr_pkg is
 
     impure function
     length(
-      ptr : integer_vector_ptr_t
+      ptr : ptr_t
     ) return integer is begin
       return ptrs(ptr.index)'length;
     end;
 
     procedure
     set(
-      ptr   : integer_vector_ptr_t;
+      ptr   : ptr_t;
       index : integer;
-      value : integer
+      value : val_t
     ) is begin
       ptrs(ptr.index)(index) := value;
     end;
 
     impure function
     get(
-      ptr   : integer_vector_ptr_t;
+      ptr   : ptr_t;
       index : integer
-    ) return integer is begin
+    ) return val_t is begin
       return ptrs(ptr.index)(index);
     end;
 
     procedure
     reallocate(
-      ptr    : integer_vector_ptr_t;
+      ptr    : ptr_t;
       length : natural;
-      value  : integer := 0
+      value  : val_t := 0
     ) is begin
       deallocate(ptrs(ptr.index));
       ptrs(ptr.index) := new integer_vector'(0 to length - 1 => value);
@@ -131,21 +131,19 @@ package body integer_vector_ptr_pkg is
 
     procedure
     resize(
-      ptr    : integer_vector_ptr_t;
+      ptr    : ptr_t;
       length : natural;
       drop   : natural := 0;
-      value  : integer := 0
+      value  : val_t := 0
     ) is
       variable old_ptr, new_ptr : integer_vector_access_t;
       variable min_length : natural := length;
     begin
       new_ptr := new integer_vector'(0 to length - 1 => value);
       old_ptr := ptrs(ptr.index);
-
       if min_length > old_ptr'length - drop then
         min_length := old_ptr'length - drop;
       end if;
-
       for i in 0 to min_length-1 loop
         new_ptr(i) := old_ptr(drop + i);
       end loop;
@@ -159,7 +157,7 @@ package body integer_vector_ptr_pkg is
 
   function
   to_integer(
-    value : integer_vector_ptr_t
+    value : ptr_t
   ) return integer is begin
     return value.index;
   end;
@@ -167,7 +165,7 @@ package body integer_vector_ptr_pkg is
   impure function
   to_integer_vector_ptr(
     value : integer
-  ) return integer_vector_ptr_t is begin
+  ) return ptr_t is begin
     -- @TODO maybe assert that the index is valid
     return (index => value);
   end;
@@ -175,64 +173,64 @@ package body integer_vector_ptr_pkg is
   impure function
   new_integer_vector_ptr(
     length : natural := 0;
-    value  : integer := 0
-  ) return integer_vector_ptr_t is begin
+    value  : val_t := 0
+  ) return ptr_t is begin
     return integer_vector_ptr_storage.new_integer_vector_ptr(length, value);
   end;
 
   procedure
   deallocate(
-    ptr : integer_vector_ptr_t
+    ptr : ptr_t
   ) is begin
     integer_vector_ptr_storage.deallocate(ptr);
   end;
 
   impure function
   length(
-    ptr : integer_vector_ptr_t
+    ptr : ptr_t
   ) return integer is begin
     return integer_vector_ptr_storage.length(ptr);
   end;
 
   procedure
   set(
-    ptr   : integer_vector_ptr_t;
+    ptr   : ptr_t;
     index : integer;
-    value : integer
+    value : val_t
   ) is begin
     integer_vector_ptr_storage.set(ptr, index, value);
   end;
 
   impure function
   get(
-    ptr   : integer_vector_ptr_t;
+    ptr   : ptr_t;
     index : integer
-  ) return integer is begin
+  ) return val_t is begin
     return integer_vector_ptr_storage.get(ptr, index);
   end;
 
   procedure
   reallocate(
-    ptr    : integer_vector_ptr_t;
+    ptr    : ptr_t;
     length : natural;
-    value  : integer := 0
+    value  : val_t := 0
   ) is begin
     integer_vector_ptr_storage.reallocate(ptr, length, value);
   end;
 
   procedure
   resize(
-    ptr    : integer_vector_ptr_t;
+    ptr    : ptr_t;
     length : natural;
     drop   : natural := 0;
-    value  : integer := 0
+    value  : val_t := 0
   ) is begin
     integer_vector_ptr_storage.resize(ptr, length, drop, value);
   end;
 
   function
   encode(
-    data : integer_vector_ptr_t
+    data : ptr_t
   ) return string is begin
     return encode(data.index);
   end;
@@ -240,8 +238,8 @@ package body integer_vector_ptr_pkg is
   function
   decode(
     code : string
-  ) return integer_vector_ptr_t is
-    variable ret_val : integer_vector_ptr_t;
+  ) return ptr_t is
+    variable ret_val : ptr_t;
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -252,7 +250,7 @@ package body integer_vector_ptr_pkg is
   decode(
     constant code   : string;
     variable index  : inout positive;
-    variable result : out integer_vector_ptr_t
+    variable result : out ptr_t
   ) is begin
     decode(code, index, result.index);
   end;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -10,8 +10,8 @@ package body integer_vector_ptr_pkg is
 
   impure function
   new_integer_vector_ptr(
-    length : natural := 0;
-    value  : val_t := 0
+    len   : natural := 0;
+    value : val_t   := 0
   ) return ptr_t is
     variable old_ptrs : vava_t;
   begin
@@ -29,7 +29,7 @@ package body integer_vector_ptr_pkg is
       deallocate(old_ptrs);
     end if;
 
-    ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
+    ptrs(current_index) := new integer_vector_t'(0 to len-1 => value);
     current_index := current_index + 1;
     return (ref => current_index-1);
   end;
@@ -68,30 +68,30 @@ package body integer_vector_ptr_pkg is
 
   procedure
   reallocate(
-    ptr    : ptr_t;
-    length : natural;
-    value  : val_t := 0
+    ptr   : ptr_t;
+    len   : natural;
+    value : val_t := 0
   ) is begin
     deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := new integer_vector_t'(0 to length - 1 => value);
+    ptrs(ptr.ref) := new integer_vector_t'(0 to len - 1 => value);
   end;
 
   procedure
   resize(
-    ptr    : ptr_t;
-    length : natural;
-    drop   : natural := 0;
-    value  : val_t := 0
+    ptr   : ptr_t;
+    len   : natural;
+    drop  : natural := 0;
+    value : val_t := 0
   ) is
     variable old_ptr, new_ptr : integer_vector_access_t;
-    variable min_length : natural := length;
+    variable min_len : natural := len;
   begin
-    new_ptr := new integer_vector_t'(0 to length - 1 => value);
+    new_ptr := new integer_vector_t'(0 to len - 1 => value);
     old_ptr := ptrs(ptr.ref);
-    if min_length > old_ptr'length - drop then
-      min_length := old_ptr'length - drop;
+    if min_len > old_ptr'length - drop then
+      min_len := old_ptr'length - drop;
     end if;
-    for i in 0 to min_length-1 loop
+    for i in 0 to min_len-1 loop
       new_ptr(i) := old_ptr(drop + i);
     end loop;
     ptrs(ptr.ref) := new_ptr;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -13,7 +13,11 @@ package body integer_vector_ptr_pkg is
   shared variable current_index : integer := 0;
   shared variable ptrs : integer_vector_access_vector_access_t := null;
 
-  impure function new_integer_vector_ptr(length : natural := 0; value : integer := 0) return integer_vector_ptr_t is
+  impure function
+  new_integer_vector_ptr(
+    length : natural := 0;
+    value  : integer := 0
+  ) return integer_vector_ptr_t is
     variable old_ptrs : integer_vector_access_vector_access_t;
     variable retval : integer_vector_ptr_t := (index => current_index);
   begin
@@ -34,36 +38,57 @@ package body integer_vector_ptr_pkg is
     ptrs(current_index) := new integer_vector'(0 to length-1 => value);
     current_index := current_index + 1;
     return retval;
-  end function;
+  end;
 
-  procedure deallocate(ptr : integer_vector_ptr_t) is
-  begin
+  procedure
+  deallocate(
+    ptr : integer_vector_ptr_t
+  ) is begin
     deallocate(ptrs(ptr.index));
     ptrs(ptr.index) := null;
-  end procedure;
+  end;
 
-  impure function length(ptr : integer_vector_ptr_t) return integer is
-  begin
+  impure function
+  length(
+    ptr : integer_vector_ptr_t
+  ) return integer is begin
     return ptrs(ptr.index)'length;
-  end function;
+  end;
 
-  procedure set(ptr : integer_vector_ptr_t; index : integer; value : integer) is
-  begin
+  procedure
+  set(
+    ptr   : integer_vector_ptr_t;
+    index : integer;
+    value : integer
+  ) is begin
     ptrs(ptr.index)(index) := value;
-  end procedure;
+  end;
 
-  impure function get(ptr : integer_vector_ptr_t; index : integer) return integer is
-  begin
+  impure function
+  get(
+    ptr   : integer_vector_ptr_t;
+    index : integer
+  ) return integer is begin
     return ptrs(ptr.index)(index);
-  end function;
+  end;
 
-  procedure reallocate(ptr : integer_vector_ptr_t; length : natural; value : integer := 0) is
-  begin
+  procedure
+  reallocate(
+    ptr    : integer_vector_ptr_t;
+    length : natural;
+    value  : integer := 0
+  ) is begin
     deallocate(ptrs(ptr.index));
     ptrs(ptr.index) := new integer_vector'(0 to length - 1 => value);
-  end procedure;
+  end;
 
-  procedure resize(ptr : integer_vector_ptr_t; length : natural; drop : natural := 0; value : integer := 0) is
+  procedure
+  resize(
+    ptr    : integer_vector_ptr_t;
+    length : natural;
+    drop   : natural := 0;
+    value  : integer := 0
+  ) is
     variable old_ptr, new_ptr : integer_vector_access_t;
     variable min_length : natural := length;
   begin
@@ -80,38 +105,47 @@ package body integer_vector_ptr_pkg is
 
     ptrs(ptr.index) := new_ptr;
     deallocate(old_ptr);
-  end procedure;
+  end;
 
-  function to_integer(value : integer_vector_ptr_t) return integer is
-  begin
+  function
+  to_integer(
+    value : integer_vector_ptr_t
+  ) return integer is begin
     return value.index;
-  end function;
+  end;
 
-  impure function to_integer_vector_ptr(value : integer) return integer_vector_ptr_t is
-  begin
+  impure function
+  to_integer_vector_ptr(
+    value : integer
+  ) return integer_vector_ptr_t is begin
     -- @TODO maybe assert that the index is valid
     return (index => value);
-  end function;
+  end;
 
-  function encode(data : integer_vector_ptr_t) return string is
-  begin
+  function
+  encode(
+    data : integer_vector_ptr_t
+  ) return string is begin
     return encode(data.index);
   end;
 
-  function decode(code : string) return integer_vector_ptr_t is
+  function
+  decode(
+    code : string
+  ) return integer_vector_ptr_t is
     variable ret_val : integer_vector_ptr_t;
-    variable index : positive := code'left;
+    variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
-
     return ret_val;
   end;
 
-  procedure decode (
-    constant code : string;
-    variable index : inout positive;
-    variable result : out integer_vector_ptr_t) is
-  begin
+  procedure
+  decode(
+    constant code   : string;
+    variable index  : inout positive;
+    variable result : out integer_vector_ptr_t
+  ) is begin
     decode(code, index, result.index);
   end;
 

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -8,14 +8,12 @@ package body integer_vector_ptr_pkg is
   shared variable current_index : integer := 0;
   shared variable ptrs : vava_t := null;
 
-  impure function
-  new_integer_vector_ptr(
+  impure function new_integer_vector_ptr (
     len   : natural := 0;
     value : val_t   := 0
   ) return ptr_t is
     variable old_ptrs : vava_t;
   begin
-
     if ptrs = null then
       ptrs := new vav_t'(0 => null);
     elsif ptrs'length <= current_index then
@@ -28,29 +26,25 @@ package body integer_vector_ptr_pkg is
       end loop;
       deallocate(old_ptrs);
     end if;
-
     ptrs(current_index) := new integer_vector_t'(0 to len-1 => value);
     current_index := current_index + 1;
     return (ref => current_index-1);
   end;
 
-  procedure
-  deallocate(
+  procedure deallocate (
     ptr : ptr_t
   ) is begin
     deallocate(ptrs(ptr.ref));
     ptrs(ptr.ref) := null;
   end;
 
-  impure function
-  length(
+  impure function length (
     ptr : ptr_t
   ) return integer is begin
     return ptrs(ptr.ref)'length;
   end;
 
-  procedure
-  set(
+  procedure set (
     ptr   : ptr_t;
     index : natural;
     value : val_t
@@ -58,16 +52,14 @@ package body integer_vector_ptr_pkg is
     ptrs(ptr.ref)(index) := value;
   end;
 
-  impure function
-  get(
+  impure function get (
     ptr   : ptr_t;
     index : natural
   ) return val_t is begin
     return ptrs(ptr.ref)(index);
   end;
 
-  procedure
-  reallocate(
+  procedure reallocate (
     ptr   : ptr_t;
     len   : natural;
     value : val_t := 0
@@ -76,8 +68,7 @@ package body integer_vector_ptr_pkg is
     ptrs(ptr.ref) := new integer_vector_t'(0 to len - 1 => value);
   end;
 
-  procedure
-  resize(
+  procedure resize (
     ptr   : ptr_t;
     len   : natural;
     drop  : natural := 0;
@@ -98,30 +89,26 @@ package body integer_vector_ptr_pkg is
     deallocate(old_ptr);
   end;
 
-  function
-  to_integer(
+  function to_integer (
     value : ptr_t
   ) return integer is begin
     return value.ref;
   end;
 
-  impure function
-  to_integer_vector_ptr(
+  impure function to_integer_vector_ptr (
     value : integer
   ) return ptr_t is begin
     -- @TODO maybe assert that the ref is valid
     return (ref => value);
   end;
 
-  function
-  encode(
+  function encode (
     data : ptr_t
   ) return string is begin
     return encode(data.ref);
   end;
 
-  function
-  decode(
+  function decode (
     code : string
   ) return ptr_t is
     variable ret_val : ptr_t;
@@ -131,8 +118,7 @@ package body integer_vector_ptr_pkg is
     return ret_val;
   end;
 
-  procedure
-  decode(
+  procedure decode (
     constant code   : string;
     variable index  : inout positive;
     variable result : out ptr_t

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -5,11 +5,6 @@
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 package body integer_vector_ptr_pkg is
-  type integer_vector_t is array (natural range <>) of integer;
-  type integer_vector_access_t is access integer_vector_t;
-  type integer_vector_access_vector_t is array (natural range <>) of integer_vector_access_t;
-  type integer_vector_access_vector_access_t is access integer_vector_access_vector_t;
-
   shared variable current_index : integer := 0;
   shared variable ptrs : vava_t := null;
 
@@ -35,7 +30,7 @@ package body integer_vector_ptr_pkg is
       deallocate(old_ptrs);
     end if;
 
-    ptrs(current_index) := new integer_vector'(0 to length-1 => value);
+    ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
     current_index := current_index + 1;
     return retval;
   end;
@@ -79,7 +74,7 @@ package body integer_vector_ptr_pkg is
     value  : val_t := 0
   ) is begin
     deallocate(ptrs(ptr.index));
-    ptrs(ptr.index) := new integer_vector'(0 to length - 1 => value);
+    ptrs(ptr.index) := new integer_vector_t'(0 to length - 1 => value);
   end;
 
   procedure
@@ -92,7 +87,7 @@ package body integer_vector_ptr_pkg is
     variable old_ptr, new_ptr : integer_vector_access_t;
     variable min_length : natural := length;
   begin
-    new_ptr := new integer_vector'(0 to length - 1 => value);
+    new_ptr := new integer_vector_t'(0 to length - 1 => value);
     old_ptr := ptrs(ptr.index);
     if min_length > old_ptr'length - drop then
       min_length := old_ptr'length - drop;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -14,7 +14,6 @@ package body integer_vector_ptr_pkg is
     value  : val_t := 0
   ) return ptr_t is
     variable old_ptrs : vava_t;
-    variable retval : ptr_t := (index => current_index);
   begin
 
     if ptrs = null then
@@ -32,22 +31,22 @@ package body integer_vector_ptr_pkg is
 
     ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
     current_index := current_index + 1;
-    return retval;
+    return (ref => current_index-1);
   end;
 
   procedure
   deallocate(
     ptr : ptr_t
   ) is begin
-    deallocate(ptrs(ptr.index));
-    ptrs(ptr.index) := null;
+    deallocate(ptrs(ptr.ref));
+    ptrs(ptr.ref) := null;
   end;
 
   impure function
   length(
     ptr : ptr_t
   ) return integer is begin
-    return ptrs(ptr.index)'length;
+    return ptrs(ptr.ref)'length;
   end;
 
   procedure
@@ -56,7 +55,7 @@ package body integer_vector_ptr_pkg is
     index : integer;
     value : val_t
   ) is begin
-    ptrs(ptr.index)(index) := value;
+    ptrs(ptr.ref)(index) := value;
   end;
 
   impure function
@@ -64,7 +63,7 @@ package body integer_vector_ptr_pkg is
     ptr   : ptr_t;
     index : integer
   ) return val_t is begin
-    return ptrs(ptr.index)(index);
+    return ptrs(ptr.ref)(index);
   end;
 
   procedure
@@ -73,8 +72,8 @@ package body integer_vector_ptr_pkg is
     length : natural;
     value  : val_t := 0
   ) is begin
-    deallocate(ptrs(ptr.index));
-    ptrs(ptr.index) := new integer_vector_t'(0 to length - 1 => value);
+    deallocate(ptrs(ptr.ref));
+    ptrs(ptr.ref) := new integer_vector_t'(0 to length - 1 => value);
   end;
 
   procedure
@@ -88,14 +87,14 @@ package body integer_vector_ptr_pkg is
     variable min_length : natural := length;
   begin
     new_ptr := new integer_vector_t'(0 to length - 1 => value);
-    old_ptr := ptrs(ptr.index);
+    old_ptr := ptrs(ptr.ref);
     if min_length > old_ptr'length - drop then
       min_length := old_ptr'length - drop;
     end if;
     for i in 0 to min_length-1 loop
       new_ptr(i) := old_ptr(drop + i);
     end loop;
-    ptrs(ptr.index) := new_ptr;
+    ptrs(ptr.ref) := new_ptr;
     deallocate(old_ptr);
   end;
 
@@ -103,22 +102,22 @@ package body integer_vector_ptr_pkg is
   to_integer(
     value : ptr_t
   ) return integer is begin
-    return value.index;
+    return value.ref;
   end;
 
   impure function
   to_integer_vector_ptr(
     value : integer
   ) return ptr_t is begin
-    -- @TODO maybe assert that the index is valid
-    return (index => value);
+    -- @TODO maybe assert that the ref is valid
+    return (ref => value);
   end;
 
   function
   encode(
     data : ptr_t
   ) return string is begin
-    return encode(data.index);
+    return encode(data.ref);
   end;
 
   function
@@ -138,7 +137,7 @@ package body integer_vector_ptr_pkg is
     variable index  : inout positive;
     variable result : out ptr_t
   ) is begin
-    decode(code, index, result.index);
+    decode(code, index, result.ref);
   end;
 
 end package body;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -52,7 +52,7 @@ package body integer_vector_ptr_pkg is
   procedure
   set(
     ptr   : ptr_t;
-    index : integer;
+    index : natural;
     value : val_t
   ) is begin
     ptrs(ptr.ref)(index) := value;
@@ -61,7 +61,7 @@ package body integer_vector_ptr_pkg is
   impure function
   get(
     ptr   : ptr_t;
-    index : integer
+    index : natural
   ) return val_t is begin
     return ptrs(ptr.ref)(index);
   end;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -11,6 +11,8 @@
 -- into a singleton datastructure of integer vector access types.
 --
 
+use work.integer_vector_pkg.all;
+
 use work.codec_pkg.all;
 use work.codec_builder_pkg.all;
 

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -21,79 +21,85 @@ package integer_vector_ptr_pkg is
   end record;
   constant null_ptr : integer_vector_ptr_t := (index => -1);
 
+  alias  ptr_t  is integer_vector_ptr_t;
+  alias  val_t  is integer;
+  alias  vec_t  is integer_vector_t;
+  alias  vav_t  is integer_vector_access_vector_t;
+  alias  vava_t is integer_vector_access_vector_access_t;
+
   function
   to_integer(
-    value : integer_vector_ptr_t
+    value : ptr_t
   ) return integer;
 
   impure function
   to_integer_vector_ptr(
-    value : integer
-  ) return integer_vector_ptr_t;
+    value : val_t
+  ) return ptr_t;
 
   impure function
   new_integer_vector_ptr(
     length : natural := 0;
-    value  : integer := 0
-  ) return integer_vector_ptr_t;
+    value  : val_t := 0
+  ) return ptr_t;
 
   procedure
   deallocate(
-    ptr : integer_vector_ptr_t
+    ptr : ptr_t
   );
 
   impure function
   length(
-    ptr : integer_vector_ptr_t
+    ptr : ptr_t
   ) return integer;
 
   procedure
   set(
-    ptr   : integer_vector_ptr_t;
+    ptr   : ptr_t;
     index : integer;
-    value : integer
+    value : val_t
   );
 
   impure function
   get(
-    ptr   : integer_vector_ptr_t;
+    ptr   : ptr_t;
     index : integer
-  ) return integer;
+  ) return val_t;
 
   procedure
   reallocate(
-    ptr    : integer_vector_ptr_t;
+    ptr    : ptr_t;
     length : natural;
-    value  : integer := 0
+    value  : val_t := 0
   );
 
   procedure
   resize(
-    ptr    : integer_vector_ptr_t;
+    ptr    : ptr_t;
     length : natural;
     drop   : natural := 0;
-    value  : integer := 0
+    value  : val_t := 0
   );
 
   function
   encode(
-    data : integer_vector_ptr_t
+    data : ptr_t
   ) return string;
 
   function
   decode(
     code : string
-  ) return integer_vector_ptr_t;
+  ) return ptr_t;
 
   procedure
   decode(
     constant code   : string;
     variable index  : inout positive;
-    variable result : out integer_vector_ptr_t
+    variable result : out ptr_t
   );
 
-  alias encode_integer_vector_ptr_t is encode[integer_vector_ptr_t return string];
-  alias decode_integer_vector_ptr_t is decode[string return integer_vector_ptr_t];
+  alias encode_integer_vector_ptr_t is encode[ptr_t return string];
+  alias decode_integer_vector_ptr_t is decode[string return ptr_t];
 
   constant integer_vector_ptr_t_code_length : positive := integer_code_length;
 

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -58,14 +58,14 @@ package integer_vector_ptr_pkg is
   procedure
   set(
     ptr   : ptr_t;
-    index : integer;
+    index : natural;
     value : val_t
   );
 
   impure function
   get(
     ptr   : ptr_t;
-    index : integer
+    index : natural
   ) return val_t;
 
   procedure

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -21,23 +21,80 @@ package integer_vector_ptr_pkg is
   end record;
   constant null_ptr : integer_vector_ptr_t := (index => -1);
 
-  function to_integer(value : integer_vector_ptr_t) return integer;
-  impure function to_integer_vector_ptr(value : integer) return integer_vector_ptr_t;
-  impure function new_integer_vector_ptr(length : natural := 0; value : integer := 0) return integer_vector_ptr_t;
-  procedure deallocate(ptr : integer_vector_ptr_t);
-  impure function length(ptr : integer_vector_ptr_t) return integer;
-  procedure set(ptr : integer_vector_ptr_t; index : integer; value : integer);
-  impure function get(ptr : integer_vector_ptr_t; index : integer) return integer;
-  procedure reallocate(ptr : integer_vector_ptr_t; length : natural; value : integer := 0);
-  procedure resize(ptr : integer_vector_ptr_t; length : natural; drop : natural := 0; value : integer := 0);
-  constant integer_vector_ptr_t_code_length : positive := integer_code_length;
-  function encode(data : integer_vector_ptr_t) return string;
-  function decode(code : string) return integer_vector_ptr_t;
-  procedure decode(
+  function
+  to_integer(
+    value : integer_vector_ptr_t
+  ) return integer;
+
+  impure function
+  to_integer_vector_ptr(
+    value : integer
+  ) return integer_vector_ptr_t;
+
+  impure function
+  new_integer_vector_ptr(
+    length : natural := 0;
+    value  : integer := 0
+  ) return integer_vector_ptr_t;
+
+  procedure
+  deallocate(
+    ptr : integer_vector_ptr_t
+  );
+
+  impure function
+  length(
+    ptr : integer_vector_ptr_t
+  ) return integer;
+
+  procedure
+  set(
+    ptr   : integer_vector_ptr_t;
+    index : integer;
+    value : integer
+  );
+
+  impure function
+  get(
+    ptr   : integer_vector_ptr_t;
+    index : integer
+  ) return integer;
+
+  procedure
+  reallocate(
+    ptr    : integer_vector_ptr_t;
+    length : natural;
+    value  : integer := 0
+  );
+
+  procedure
+  resize(
+    ptr    : integer_vector_ptr_t;
+    length : natural;
+    drop   : natural := 0;
+    value  : integer := 0
+  );
+
+  function
+  encode(
+    data : integer_vector_ptr_t
+  ) return string;
+
+  function
+  decode(
+    code : string
+  ) return integer_vector_ptr_t;
+
+  procedure
+  decode(
     constant code   : string;
-    variable index : inout positive;
-    variable result : out integer_vector_ptr_t);
+    variable index  : inout positive;
+    variable result : out integer_vector_ptr_t
+  );
+
   alias encode_integer_vector_ptr_t is encode[integer_vector_ptr_t return string];
   alias decode_integer_vector_ptr_t is decode[string return integer_vector_ptr_t];
+
+  constant integer_vector_ptr_t_code_length : positive := integer_code_length;
 
 end package;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -29,72 +29,60 @@ package integer_vector_ptr_pkg is
   alias  vav_t  is integer_vector_access_vector_t;
   alias  vava_t is integer_vector_access_vector_access_t;
 
-  function
-  to_integer(
+  function to_integer (
     value : ptr_t
   ) return integer;
 
-  impure function
-  to_integer_vector_ptr(
+  impure function to_integer_vector_ptr (
     value : val_t
   ) return ptr_t;
 
-  impure function
-  new_integer_vector_ptr(
+  impure function new_integer_vector_ptr (
     len   : natural := 0;
     value : val_t := 0
   ) return ptr_t;
 
-  procedure
-  deallocate(
+  procedure deallocate (
     ptr : ptr_t
   );
 
-  impure function
-  length(
+  impure function length (
     ptr : ptr_t
   ) return integer;
 
-  procedure
-  set(
+  procedure set (
     ptr   : ptr_t;
     index : natural;
     value : val_t
   );
 
-  impure function
-  get(
+  impure function get (
     ptr   : ptr_t;
     index : natural
   ) return val_t;
 
-  procedure
-  reallocate(
+  procedure reallocate (
     ptr   : ptr_t;
     len   : natural;
     value : val_t := 0
   );
 
-  procedure
-  resize(
+  procedure resize (
     ptr   : ptr_t;
     len   : natural;
     drop  : natural := 0;
     value : val_t := 0
   );
 
-  function
-  encode(
+  function encode (
     data : ptr_t
   ) return string;
 
-  function
-  decode(
+  function decode (
     code : string
   ) return ptr_t;
 
-  procedure
-  decode(
+  procedure decode (
     constant code   : string;
     variable index  : inout positive;
     variable result : out ptr_t

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -19,9 +19,9 @@ use work.codec_builder_pkg.all;
 package integer_vector_ptr_pkg is
   subtype index_t is integer range -1 to integer'high;
   type integer_vector_ptr_t is record
-    index : index_t;
+    ref : index_t;
   end record;
-  constant null_ptr : integer_vector_ptr_t := (index => -1);
+  constant null_ptr : integer_vector_ptr_t := (ref => -1);
 
   alias  ptr_t  is integer_vector_ptr_t;
   alias  val_t  is integer;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -41,8 +41,8 @@ package integer_vector_ptr_pkg is
 
   impure function
   new_integer_vector_ptr(
-    length : natural := 0;
-    value  : val_t := 0
+    len   : natural := 0;
+    value : val_t := 0
   ) return ptr_t;
 
   procedure
@@ -70,17 +70,17 @@ package integer_vector_ptr_pkg is
 
   procedure
   reallocate(
-    ptr    : ptr_t;
-    length : natural;
-    value  : val_t := 0
+    ptr   : ptr_t;
+    len   : natural;
+    value : val_t := 0
   );
 
   procedure
   resize(
-    ptr    : ptr_t;
-    length : natural;
-    drop   : natural := 0;
-    value  : val_t := 0
+    ptr   : ptr_t;
+    len   : natural;
+    drop  : natural := 0;
+    value : val_t := 0
   );
 
   function

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pool_pkg.vhd
@@ -11,51 +11,64 @@ use work.integer_vector_ptr_pkg.all;
 use work.queue_pkg.all;
 
 package integer_vector_ptr_pool_pkg is
-
   type integer_vector_ptr_pool_t is record
     ptrs : queue_t;
   end record;
   constant null_integer_vector_ptr_pool : integer_vector_ptr_pool_t := (others => null_queue);
 
-  impure function new_integer_vector_ptr_pool return integer_vector_ptr_pool_t;
-  impure function new_integer_vector_ptr(pool : integer_vector_ptr_pool_t; min_length : natural := 0) return integer_vector_ptr_t;
-  procedure recycle(pool : integer_vector_ptr_pool_t; variable ptr : inout integer_vector_ptr_t);
+  impure function
+  new_integer_vector_ptr_pool
+  return integer_vector_ptr_pool_t;
 
+  impure function
+  new_integer_vector_ptr(
+    pool       : integer_vector_ptr_pool_t;
+    min_length : natural := 0
+  ) return integer_vector_ptr_t;
+
+  procedure
+  recycle(
+    pool : integer_vector_ptr_pool_t;
+    variable ptr : inout integer_vector_ptr_t
+  );
 end package;
 
 package body integer_vector_ptr_pool_pkg is
-
-  impure function new_integer_vector_ptr_pool return integer_vector_ptr_pool_t is
-  begin
+  impure function
+  new_integer_vector_ptr_pool return integer_vector_ptr_pool_t is begin
     return (ptrs => new_queue);
   end;
 
-  impure function new_integer_vector_ptr(pool : integer_vector_ptr_pool_t; min_length : natural := 0) return integer_vector_ptr_t is
+  impure function
+  new_integer_vector_ptr(
+    pool       : integer_vector_ptr_pool_t;
+    min_length : natural := 0
+  ) return integer_vector_ptr_t is
     variable ptr : integer_vector_ptr_t;
   begin
     if length(pool.ptrs) > 0 then
       -- Reuse
       ptr := pop_integer_vector_ptr_ref(pool.ptrs);
-
       if length(ptr) < min_length then
         reallocate(ptr, min_length);
       end if;
     else
-
       -- Allocate new
       ptr := new_integer_vector_ptr(min_length);
     end if;
     return ptr;
   end;
 
-  procedure recycle(pool : integer_vector_ptr_pool_t; variable ptr : inout integer_vector_ptr_t) is
-  begin
+  procedure
+  recycle(
+    pool : integer_vector_ptr_pool_t;
+    variable ptr : inout integer_vector_ptr_t
+  ) is begin
     if ptr = null_ptr then
       return;
     end if;
-
     push_integer_vector_ptr_ref(pool.ptrs, ptr);
     ptr := null_ptr;
-  end procedure;
+  end;
 
 end package body;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pool_pkg.vhd
@@ -16,31 +16,27 @@ package integer_vector_ptr_pool_pkg is
   end record;
   constant null_integer_vector_ptr_pool : integer_vector_ptr_pool_t := (others => null_queue);
 
-  impure function
-  new_integer_vector_ptr_pool
+  impure function new_integer_vector_ptr_pool
   return integer_vector_ptr_pool_t;
 
-  impure function
-  new_integer_vector_ptr(
+  impure function new_integer_vector_ptr (
     pool       : integer_vector_ptr_pool_t;
     min_length : natural := 0
   ) return integer_vector_ptr_t;
 
-  procedure
-  recycle(
-    pool : integer_vector_ptr_pool_t;
+  procedure recycle (
+    pool         : integer_vector_ptr_pool_t;
     variable ptr : inout integer_vector_ptr_t
   );
 end package;
 
 package body integer_vector_ptr_pool_pkg is
-  impure function
-  new_integer_vector_ptr_pool return integer_vector_ptr_pool_t is begin
+  impure function new_integer_vector_ptr_pool
+  return integer_vector_ptr_pool_t is begin
     return (ptrs => new_queue);
   end;
 
-  impure function
-  new_integer_vector_ptr(
+  impure function new_integer_vector_ptr (
     pool       : integer_vector_ptr_pool_t;
     min_length : natural := 0
   ) return integer_vector_ptr_t is
@@ -59,9 +55,8 @@ package body integer_vector_ptr_pool_pkg is
     return ptr;
   end;
 
-  procedure
-  recycle(
-    pool : integer_vector_ptr_pool_t;
+  procedure recycle (
+    pool         : integer_vector_ptr_pool_t;
     variable ptr : inout integer_vector_ptr_t
   ) is begin
     if ptr = null_ptr then

--- a/vunit/vhdl/data_types/src/queue_pkg-2008.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-2008.vhd
@@ -13,98 +13,84 @@ use work.codec_2008_pkg.all;
 use work.codec_builder_2008_pkg.all;
 
 package queue_2008_pkg is
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : boolean_vector
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return boolean_vector;
 
   alias push_boolean_vector is push[queue_t, boolean_vector];
   alias pop_boolean_vector is pop[queue_t return boolean_vector];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : integer_vector
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return integer_vector;
 
   alias push_integer_vector is push[queue_t, integer_vector];
   alias pop_integer_vector is pop[queue_t return integer_vector];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : real_vector
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return real_vector;
 
   alias push_real_vector is push[queue_t, real_vector];
   alias pop_real_vector is pop[queue_t return real_vector];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : time_vector
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return time_vector;
 
   alias push_time_vector is push[queue_t, time_vector];
   alias pop_time_vector is pop[queue_t return time_vector];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ufixed
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ufixed;
 
   alias push_ufixed is push[queue_t, ufixed];
   alias pop_ufixed is pop[queue_t return ufixed];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : sfixed
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return sfixed;
 
   alias push_sfixed is push[queue_t, sfixed];
   alias pop_sfixed is pop[queue_t return sfixed];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : float
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return float;
 
@@ -113,8 +99,7 @@ package queue_2008_pkg is
 end package;
 
 package body queue_2008_pkg is
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : boolean_vector
   ) is begin
@@ -122,16 +107,14 @@ package body queue_2008_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return boolean_vector is begin
     check_type(queue, vhdl_boolean_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : integer_vector
   ) is begin
@@ -139,16 +122,14 @@ package body queue_2008_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return integer_vector is begin
     check_type(queue, vhdl_integer_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : real_vector
   ) is begin
@@ -156,15 +137,14 @@ package body queue_2008_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return real_vector is begin
     check_type(queue, vhdl_real_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(
+  procedure push (
     queue : queue_t;
     value : time_vector
   ) is begin
@@ -172,16 +152,14 @@ package body queue_2008_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return time_vector is begin
     check_type(queue, vhdl_time_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ufixed
   ) is begin
@@ -189,16 +167,14 @@ package body queue_2008_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ufixed is begin
     check_type(queue, ieee_ufixed);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : sfixed
   ) is begin
@@ -206,15 +182,14 @@ package body queue_2008_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return sfixed is begin
     check_type(queue, ieee_sfixed);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(
+  procedure push (
     queue : queue_t;
     value : float
   ) is begin
@@ -222,8 +197,7 @@ package body queue_2008_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return float is begin
     check_type(queue, ieee_float);

--- a/vunit/vhdl/data_types/src/queue_pkg-2008.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-2008.vhd
@@ -13,123 +13,219 @@ use work.codec_2008_pkg.all;
 use work.codec_builder_2008_pkg.all;
 
 package queue_2008_pkg is
-  procedure push(queue : queue_t; value : boolean_vector);
-  impure function pop(queue : queue_t) return boolean_vector;
+  procedure
+  push(
+    queue : queue_t;
+    value : boolean_vector
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return boolean_vector;
+
   alias push_boolean_vector is push[queue_t, boolean_vector];
   alias pop_boolean_vector is pop[queue_t return boolean_vector];
 
-  procedure push(queue : queue_t; value : integer_vector);
-  impure function pop(queue : queue_t) return integer_vector;
+  procedure
+  push(
+    queue : queue_t;
+    value : integer_vector
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return integer_vector;
+
   alias push_integer_vector is push[queue_t, integer_vector];
   alias pop_integer_vector is pop[queue_t return integer_vector];
 
-  procedure push(queue : queue_t; value : real_vector);
-  impure function pop(queue : queue_t) return real_vector;
+  procedure
+  push(
+    queue : queue_t;
+    value : real_vector
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return real_vector;
+
   alias push_real_vector is push[queue_t, real_vector];
   alias pop_real_vector is pop[queue_t return real_vector];
 
-  procedure push(queue : queue_t; value : time_vector);
-  impure function pop(queue : queue_t) return time_vector;
+  procedure
+  push(
+    queue : queue_t;
+    value : time_vector
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return time_vector;
+
   alias push_time_vector is push[queue_t, time_vector];
   alias pop_time_vector is pop[queue_t return time_vector];
 
-  procedure push(queue : queue_t; value : ufixed);
-  impure function pop(queue : queue_t) return ufixed;
+  procedure
+  push(
+    queue : queue_t;
+    value : ufixed
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return ufixed;
+
   alias push_ufixed is push[queue_t, ufixed];
   alias pop_ufixed is pop[queue_t return ufixed];
 
-  procedure push(queue : queue_t; value : sfixed);
-  impure function pop(queue : queue_t) return sfixed;
+  procedure
+  push(
+    queue : queue_t;
+    value : sfixed
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return sfixed;
+
   alias push_sfixed is push[queue_t, sfixed];
   alias pop_sfixed is pop[queue_t return sfixed];
 
-  procedure push(queue : queue_t; value : float);
-  impure function pop(queue : queue_t) return float;
+  procedure
+  push(
+    queue : queue_t;
+    value : float
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return float;
+
   alias push_float is push[queue_t, float];
   alias pop_float is pop[queue_t return float];
 end package;
 
 package body queue_2008_pkg is
-  procedure push(queue : queue_t; value : boolean_vector) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : boolean_vector
+  ) is begin
     push_type(queue, vhdl_boolean_vector);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return boolean_vector is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return boolean_vector is begin
     check_type(queue, vhdl_boolean_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : integer_vector) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : integer_vector
+  ) is begin
     push_type(queue, vhdl_integer_vector);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return integer_vector is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return integer_vector is begin
     check_type(queue, vhdl_integer_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : real_vector) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : real_vector
+  ) is begin
     push_type(queue, vhdl_real_vector);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return real_vector is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return real_vector is begin
     check_type(queue, vhdl_real_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : time_vector) is
-  begin
+  procedure push(
+    queue : queue_t;
+    value : time_vector
+  ) is begin
     push_type(queue, vhdl_time_vector);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return time_vector is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return time_vector is begin
     check_type(queue, vhdl_time_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : ufixed) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : ufixed
+  ) is begin
     push_type(queue, ieee_ufixed);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return ufixed is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return ufixed is begin
     check_type(queue, ieee_ufixed);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : sfixed) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : sfixed
+  ) is begin
     push_type(queue, ieee_sfixed);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return sfixed is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return sfixed is begin
     check_type(queue, ieee_sfixed);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : float) is
-  begin
+  procedure push(
+    queue : queue_t;
+    value : float
+  ) is begin
     push_type(queue, ieee_float);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return float is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return float is begin
     check_type(queue, ieee_float);
     return decode(pop_variable_string(queue));
   end;

--- a/vunit/vhdl/data_types/src/queue_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-body.vhd
@@ -11,69 +11,89 @@ use work.codec_pkg.all;
 use work.codec_builder_pkg.all;
 
 package body queue_pkg is
-
   constant tail_idx : natural := 0;
   constant head_idx : natural := 1;
   constant num_meta : natural := head_idx + 1;
-
   constant queue_t_code_length : positive := integer_vector_ptr_t_code_length + string_ptr_t_code_length;
 
-  impure function new_queue return queue_t is
-  begin
+  impure function
+  new_queue
+  return queue_t is begin
     return (p_meta => new_integer_vector_ptr(num_meta),
             data   => new_string_ptr);
   end;
 
-  impure function length(queue : queue_t) return natural is
+  impure function
+  length(
+    queue : queue_t
+  ) return natural is
     constant head : integer := get(queue.p_meta, head_idx);
     constant tail : integer := get(queue.p_meta, tail_idx);
   begin
     return tail - head;
   end;
 
-  impure function is_empty(queue : queue_t) return boolean is
-  begin
+  impure function
+  is_empty(
+    queue : queue_t
+  ) return boolean is begin
     return length(queue) = 0;
   end;
 
-  procedure flush(queue : queue_t) is
-  begin
+  procedure
+  flush(
+    queue : queue_t
+  ) is begin
     assert queue /= null_queue report "Flush null queue";
     set(queue.p_meta, head_idx, 0);
     set(queue.p_meta, tail_idx, 0);
   end;
 
-  impure function copy(queue : queue_t) return queue_t is
+  impure function
+  copy(
+    queue : queue_t
+  ) return queue_t is
     constant result : queue_t := new_queue;
   begin
     for i in 0 to length(queue) - 1 loop
       unsafe_push(result, get(queue.data, 1 + i));
     end loop;
-
     return result;
   end;
 
-  function encode(data : queue_t) return string is
-  begin
+  function
+  encode(
+    data : queue_t
+  ) return string is begin
     return encode(data.p_meta) & encode(to_integer(data.data));
   end;
 
-  procedure decode(constant code : string; variable index : inout positive; variable result : out queue_t) is
-  begin
+  procedure
+  decode(
+    constant code   : string;
+    variable index  : inout positive;
+    variable result : out queue_t
+  ) is begin
     decode(code, index, result.p_meta);
     decode(code, index, result.data);
   end;
 
-  function decode(code : string) return queue_t is
+  function
+  decode(
+    code : string
+  ) return queue_t is
     variable ret_val : queue_t;
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
-
     return ret_val;
   end;
 
-  procedure unsafe_push(queue : queue_t; value : character) is
+  procedure
+  unsafe_push(
+    queue : queue_t;
+    value : character
+  ) is
     variable tail : integer;
     variable head : integer;
   begin
@@ -95,7 +115,10 @@ package body queue_pkg is
     set(queue.p_meta, tail_idx, tail + 1);
   end;
 
-  impure function unsafe_pop(queue : queue_t) return character is
+  impure function
+  unsafe_pop(
+    queue : queue_t
+  ) return character is
     variable head : integer;
     variable data : character;
   begin
@@ -107,17 +130,26 @@ package body queue_pkg is
     return data;
   end;
 
-  procedure push_type(queue : queue_t; element_type : queue_element_type_t) is
-  begin
+  procedure
+  push_type(
+    queue        : queue_t;
+    element_type : queue_element_type_t
+  ) is begin
     unsafe_push(queue, character'val(queue_element_type_t'pos(element_type)));
   end;
 
-  impure function pop_type(queue : queue_t) return queue_element_type_t is
-  begin
+  impure function
+  pop_type(
+    queue : queue_t
+  ) return queue_element_type_t is begin
     return queue_element_type_t'val(character'pos(unsafe_pop(queue)));
   end;
 
-  procedure check_type(queue : queue_t; element_type : queue_element_type_t) is
+  procedure
+  check_type(
+    queue        : queue_t;
+    element_type : queue_element_type_t
+  ) is
     constant popped_type : queue_element_type_t := pop_type(queue);
   begin
     if popped_type /= element_type then
@@ -126,26 +158,37 @@ package body queue_pkg is
     end if;
   end;
 
-  procedure push(queue : queue_t; value : character) is
-  begin
+  procedure push(
+    queue : queue_t;
+    value : character
+  ) is begin
     push_type(queue, vhdl_character);
     unsafe_push(queue, value);
   end;
 
-  impure function pop(queue : queue_t) return character is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return character is begin
     check_type(queue, vhdl_character);
     return unsafe_pop(queue);
   end;
 
-  procedure push_fix_string(queue : queue_t; value : string) is
-  begin
+  procedure
+  push_fix_string(
+    queue : queue_t;
+    value : string
+  ) is begin
     for i in value'range loop
       unsafe_push(queue, value(i));
     end loop;
-  end procedure;
+  end;
 
-  impure function pop_fix_string(queue : queue_t; length : natural) return string is
+  impure function
+  pop_fix_string(
+    queue  : queue_t;
+    length : natural
+  ) return string is
     variable result : string(1 to length);
   begin
     for i in result'range loop
@@ -155,317 +198,451 @@ package body queue_pkg is
     return result;
   end;
 
-  procedure unsafe_push(queue : queue_t; value : integer) is
-  begin
+  procedure
+  unsafe_push(
+    queue : queue_t;
+    value : integer
+  ) is begin
     push_fix_string(queue, encode(value));
   end;
 
-  impure function unsafe_pop(queue : queue_t) return integer is
-  begin
+  impure function
+  unsafe_pop(
+    queue : queue_t
+  ) return integer is begin
     return decode(pop_fix_string(queue, integer_code_length));
   end;
 
-  procedure push(queue : queue_t; value : integer) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : integer
+  ) is begin
     push_type(queue, vhdl_integer);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return integer is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return integer is begin
     check_type(queue, vhdl_integer);
     return decode(pop_fix_string(queue, integer_code_length));
   end;
 
-  procedure push_byte(queue : queue_t; value : natural range 0 to 255) is
-  begin
+  procedure
+  push_byte(
+    queue : queue_t;
+    value : natural range 0 to 255
+  ) is begin
     push_type(queue, vunit_byte);
     unsafe_push(queue, character'val(value));
   end;
 
-  impure function pop_byte(queue : queue_t) return integer is
-  begin
+  impure function
+  pop_byte(
+    queue : queue_t
+  ) return integer is begin
     check_type(queue, vunit_byte);
     return character'pos(unsafe_pop(queue));
   end;
 
-  procedure push_variable_string(queue : queue_t; value : string) is
-  begin
+  procedure
+  push_variable_string(
+    queue : queue_t;
+    value : string
+  ) is begin
     unsafe_push(queue, value'length);
     push_fix_string(queue, value);
-  end procedure;
+  end;
 
-  impure function pop_variable_string(queue : queue_t) return string is
+  impure function
+  pop_variable_string(
+    queue : queue_t
+  ) return string is
     constant length : integer := unsafe_pop(queue);
   begin
     return pop_fix_string(queue, length);
   end;
 
-  procedure push(queue : queue_t; value : boolean) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : boolean
+  ) is begin
     push_type(queue, vhdl_boolean);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return boolean is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return boolean is begin
     check_type(queue, vhdl_boolean);
     return decode(pop_fix_string(queue, boolean_code_length));
   end;
 
-  procedure unsafe_push(queue : queue_t; value : boolean) is
-  begin
+  procedure
+  unsafe_push(
+    queue : queue_t;
+    value : boolean
+  ) is begin
     push_fix_string(queue, encode(value));
   end;
 
-  impure function unsafe_pop(queue : queue_t) return boolean is
-  begin
+  impure function
+  unsafe_pop(
+    queue : queue_t
+  ) return boolean is begin
     return decode(pop_fix_string(queue, boolean_code_length));
   end;
 
-  procedure push(queue : queue_t; value : real) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : real
+  ) is begin
     push_type(queue, vhdl_real);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return real is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return real is begin
     check_type(queue, vhdl_real);
     return decode(pop_fix_string(queue, real_code_length));
   end;
 
-  procedure push(queue : queue_t; value : bit) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : bit
+  ) is begin
     push_type(queue, vhdl_bit);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return bit is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return bit is begin
     check_type(queue, vhdl_bit);
     return decode(pop_fix_string(queue, bit_code_length));
   end;
 
-  procedure push(queue : queue_t; value : std_ulogic) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : std_ulogic
+  ) is begin
     push_type(queue, ieee_std_ulogic);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return std_ulogic is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return std_ulogic is begin
     check_type(queue, ieee_std_ulogic);
     return decode(pop_fix_string(queue, std_ulogic_code_length));
   end;
 
-  procedure push(queue : queue_t; value : severity_level) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : severity_level
+  ) is begin
     push_type(queue, vhdl_severity_level);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return severity_level is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return severity_level is begin
     check_type(queue, vhdl_severity_level);
     return decode(pop_fix_string(queue, severity_level_code_length));
   end;
 
-  procedure push(queue : queue_t; value : file_open_status) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : file_open_status
+  ) is begin
     push_type(queue, vhdl_file_open_status);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return file_open_status is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return file_open_status is begin
     check_type(queue, vhdl_file_open_status);
     return decode(pop_fix_string(queue, file_open_status_code_length));
   end;
 
-  procedure push(queue : queue_t; value : file_open_kind) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : file_open_kind
+  ) is begin
     push_type(queue, vhdl_file_open_kind);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return file_open_kind is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return file_open_kind is begin
     check_type(queue, vhdl_file_open_kind);
     return decode(pop_fix_string(queue, file_open_kind_code_length));
   end;
 
-  procedure push(queue : queue_t; value : bit_vector) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : bit_vector
+  ) is begin
     push_type(queue, vhdl_bit_vector);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return bit_vector is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return bit_vector is begin
     check_type(queue, vhdl_bit_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : std_ulogic_vector) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : std_ulogic_vector
+  ) is begin
     push_type(queue, vhdl_std_ulogic_vector);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return std_ulogic_vector is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return std_ulogic_vector is begin
     check_type(queue, vhdl_std_ulogic_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : complex) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : complex
+  ) is begin
     push_type(queue, ieee_complex);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return complex is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return complex is begin
     check_type(queue, ieee_complex);
     return decode(pop_fix_string(queue, complex_code_length));
   end;
 
-  procedure push(queue : queue_t; value : complex_polar) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : complex_polar
+  ) is begin
     push_type(queue, ieee_complex_polar);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return complex_polar is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return complex_polar is begin
     check_type(queue, ieee_complex_polar);
     return decode(pop_fix_string(queue, complex_polar_code_length));
   end;
 
-  procedure push(queue : queue_t; value : ieee.numeric_bit.unsigned) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : ieee.numeric_bit.unsigned
+  ) is begin
     push_type(queue, ieee_numeric_bit_unsigned);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return ieee.numeric_bit.unsigned is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return ieee.numeric_bit.unsigned is begin
     check_type(queue, ieee_numeric_bit_unsigned);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : ieee.numeric_bit.signed) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : ieee.numeric_bit.signed
+  ) is begin
     push_type(queue, ieee_numeric_bit_signed);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return ieee.numeric_bit.signed is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return ieee.numeric_bit.signed is begin
     check_type(queue, ieee_numeric_bit_signed);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : ieee.numeric_std.unsigned) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : ieee.numeric_std.unsigned
+  ) is begin
     push_type(queue, ieee_numeric_std_unsigned);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return ieee.numeric_std.unsigned is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return ieee.numeric_std.unsigned is begin
     check_type(queue, ieee_numeric_std_unsigned);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : ieee.numeric_std.signed) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : ieee.numeric_std.signed
+  ) is begin
     push_type(queue, ieee_numeric_std_signed);
     push_variable_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return ieee.numeric_std.signed is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return ieee.numeric_std.signed is begin
     check_type(queue, ieee_numeric_std_signed);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : string) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : string
+  ) is begin
     push_type(queue, vhdl_string);
     push_variable_string(queue, encode(value));
-  end procedure;
+  end;
 
-  impure function pop(queue : queue_t) return string is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return string is begin
     check_type(queue, vhdl_string);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure push(queue : queue_t; value : time) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    value : time
+  ) is begin
     push_type(queue, vhdl_time);
     push_fix_string(queue, encode(value));
   end;
 
-  impure function pop(queue : queue_t) return time is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return time is begin
     check_type(queue, vhdl_time);
     return decode(pop_fix_string(queue, time_code_length));
   end;
 
-  procedure push(queue : queue_t; variable value : inout integer_vector_ptr_t) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    variable value : inout integer_vector_ptr_t
+  ) is begin
     push_type(queue, vunit_integer_vector_ptr_t);
     push_fix_string(queue, encode(value));
     value := null_ptr;
   end;
 
-  impure function pop(queue : queue_t) return integer_vector_ptr_t is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return integer_vector_ptr_t is begin
     check_type(queue, vunit_integer_vector_ptr_t);
     return decode(pop_fix_string(queue, integer_vector_ptr_t_code_length));
   end;
 
-  procedure unsafe_push(queue : queue_t; value : integer_vector_ptr_t) is
-  begin
+  procedure
+  unsafe_push(
+    queue : queue_t;
+    value : integer_vector_ptr_t
+  ) is begin
     push_fix_string(queue, encode(value));
   end;
 
-  impure function unsafe_pop(queue : queue_t) return integer_vector_ptr_t is
-  begin
+  impure function
+  unsafe_pop(
+    queue : queue_t
+  ) return integer_vector_ptr_t is begin
     return decode(pop_fix_string(queue, integer_vector_ptr_t_code_length));
   end;
 
-  procedure push(queue : queue_t; variable value : inout string_ptr_t) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    variable value : inout string_ptr_t
+  ) is begin
     push_type(queue, vunit_string_ptr_t);
     push_fix_string(queue, encode(value));
     value := null_string_ptr;
   end;
 
-  impure function pop(queue : queue_t) return string_ptr_t is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return string_ptr_t is begin
     check_type(queue, vunit_string_ptr_t);
     return decode(pop_fix_string(queue, string_ptr_t_code_length));
   end;
 
-  procedure push(queue : queue_t; variable value : inout queue_t) is
-  begin
+  procedure
+  push(
+    queue : queue_t;
+    variable value : inout queue_t
+  ) is begin
     push_type(queue, vunit_queue_t);
     push_fix_string(queue, encode(value));
     value := null_queue;
   end;
 
-  impure function pop(queue : queue_t) return queue_t is
-  begin
+  impure function
+  pop(
+    queue : queue_t
+  ) return queue_t is begin
     check_type(queue, vunit_queue_t);
     return decode(pop_fix_string(queue, queue_t_code_length));
   end;
 
-  procedure push_ref(constant queue : queue_t; value : inout integer_array_t) is
-  begin
+  procedure
+  push_ref(
+    constant queue : queue_t;
+    value : inout integer_array_t
+  ) is begin
     push_type(queue, vunit_integer_array_t);
     unsafe_push(queue, value.length);
     unsafe_push(queue, value.width);
@@ -479,7 +656,10 @@ package body queue_pkg is
     value := null_integer_array;
   end;
 
-  impure function pop_ref(queue : queue_t) return integer_array_t is
+  impure function
+  pop_ref(
+    queue : queue_t
+  ) return integer_array_t is
     variable result : integer_array_t;
   begin
     check_type(queue, vunit_integer_array_t);
@@ -495,5 +675,4 @@ package body queue_pkg is
 
     return result;
   end;
-
 end package body;

--- a/vunit/vhdl/data_types/src/queue_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-body.vhd
@@ -16,15 +16,13 @@ package body queue_pkg is
   constant num_meta : natural := head_idx + 1;
   constant queue_t_code_length : positive := integer_vector_ptr_t_code_length + string_ptr_t_code_length;
 
-  impure function
-  new_queue
+  impure function new_queue
   return queue_t is begin
     return (p_meta => new_integer_vector_ptr(num_meta),
             data   => new_string_ptr);
   end;
 
-  impure function
-  length(
+  impure function length (
     queue : queue_t
   ) return natural is
     constant head : integer := get(queue.p_meta, head_idx);
@@ -33,15 +31,13 @@ package body queue_pkg is
     return tail - head;
   end;
 
-  impure function
-  is_empty(
+  impure function is_empty (
     queue : queue_t
   ) return boolean is begin
     return length(queue) = 0;
   end;
 
-  procedure
-  flush(
+  procedure flush (
     queue : queue_t
   ) is begin
     assert queue /= null_queue report "Flush null queue";
@@ -49,8 +45,7 @@ package body queue_pkg is
     set(queue.p_meta, tail_idx, 0);
   end;
 
-  impure function
-  copy(
+  impure function copy (
     queue : queue_t
   ) return queue_t is
     constant result : queue_t := new_queue;
@@ -61,15 +56,13 @@ package body queue_pkg is
     return result;
   end;
 
-  function
-  encode(
+  function encode (
     data : queue_t
   ) return string is begin
     return encode(data.p_meta) & encode(to_integer(data.data));
   end;
 
-  procedure
-  decode(
+  procedure decode (
     constant code   : string;
     variable index  : inout positive;
     variable result : out queue_t
@@ -78,8 +71,7 @@ package body queue_pkg is
     decode(code, index, result.data);
   end;
 
-  function
-  decode(
+  function decode (
     code : string
   ) return queue_t is
     variable ret_val : queue_t;
@@ -89,8 +81,7 @@ package body queue_pkg is
     return ret_val;
   end;
 
-  procedure
-  unsafe_push(
+  procedure unsafe_push (
     queue : queue_t;
     value : character
   ) is
@@ -100,7 +91,6 @@ package body queue_pkg is
     assert queue /= null_queue report "Push to null queue";
     tail := get(queue.p_meta, tail_idx);
     head := get(queue.p_meta, head_idx);
-
     if length(queue.data) < tail + 1 then
       -- Allocate more new data, double data to avoid
       -- to much copying.
@@ -110,13 +100,11 @@ package body queue_pkg is
       head := 0;
       set(queue.p_meta, head_idx, head);
     end if;
-
     set(queue.data, 1 + tail, value);
     set(queue.p_meta, tail_idx, tail + 1);
   end;
 
-  impure function
-  unsafe_pop(
+  impure function unsafe_pop (
     queue : queue_t
   ) return character is
     variable head : integer;
@@ -130,23 +118,20 @@ package body queue_pkg is
     return data;
   end;
 
-  procedure
-  push_type(
+  procedure push_type (
     queue        : queue_t;
     element_type : queue_element_type_t
   ) is begin
     unsafe_push(queue, character'val(queue_element_type_t'pos(element_type)));
   end;
 
-  impure function
-  pop_type(
+  impure function pop_type (
     queue : queue_t
   ) return queue_element_type_t is begin
     return queue_element_type_t'val(character'pos(unsafe_pop(queue)));
   end;
 
-  procedure
-  check_type(
+  procedure check_type (
     queue        : queue_t;
     element_type : queue_element_type_t
   ) is
@@ -158,7 +143,7 @@ package body queue_pkg is
     end if;
   end;
 
-  procedure push(
+  procedure push (
     queue : queue_t;
     value : character
   ) is begin
@@ -166,16 +151,14 @@ package body queue_pkg is
     unsafe_push(queue, value);
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return character is begin
     check_type(queue, vhdl_character);
     return unsafe_pop(queue);
   end;
 
-  procedure
-  push_fix_string(
+  procedure push_fix_string (
     queue : queue_t;
     value : string
   ) is begin
@@ -184,8 +167,7 @@ package body queue_pkg is
     end loop;
   end;
 
-  impure function
-  pop_fix_string(
+  impure function pop_fix_string (
     queue  : queue_t;
     length : natural
   ) return string is
@@ -198,23 +180,20 @@ package body queue_pkg is
     return result;
   end;
 
-  procedure
-  unsafe_push(
+  procedure unsafe_push (
     queue : queue_t;
     value : integer
   ) is begin
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  unsafe_pop(
+  impure function unsafe_pop (
     queue : queue_t
   ) return integer is begin
     return decode(pop_fix_string(queue, integer_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : integer
   ) is begin
@@ -222,16 +201,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return integer is begin
     check_type(queue, vhdl_integer);
     return decode(pop_fix_string(queue, integer_code_length));
   end;
 
-  procedure
-  push_byte(
+  procedure push_byte (
     queue : queue_t;
     value : natural range 0 to 255
   ) is begin
@@ -239,16 +216,14 @@ package body queue_pkg is
     unsafe_push(queue, character'val(value));
   end;
 
-  impure function
-  pop_byte(
+  impure function pop_byte (
     queue : queue_t
   ) return integer is begin
     check_type(queue, vunit_byte);
     return character'pos(unsafe_pop(queue));
   end;
 
-  procedure
-  push_variable_string(
+  procedure push_variable_string (
     queue : queue_t;
     value : string
   ) is begin
@@ -256,8 +231,7 @@ package body queue_pkg is
     push_fix_string(queue, value);
   end;
 
-  impure function
-  pop_variable_string(
+  impure function pop_variable_string (
     queue : queue_t
   ) return string is
     constant length : integer := unsafe_pop(queue);
@@ -265,8 +239,7 @@ package body queue_pkg is
     return pop_fix_string(queue, length);
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : boolean
   ) is begin
@@ -274,31 +247,27 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return boolean is begin
     check_type(queue, vhdl_boolean);
     return decode(pop_fix_string(queue, boolean_code_length));
   end;
 
-  procedure
-  unsafe_push(
+  procedure unsafe_push (
     queue : queue_t;
     value : boolean
   ) is begin
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  unsafe_pop(
+  impure function unsafe_pop (
     queue : queue_t
   ) return boolean is begin
     return decode(pop_fix_string(queue, boolean_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : real
   ) is begin
@@ -306,16 +275,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return real is begin
     check_type(queue, vhdl_real);
     return decode(pop_fix_string(queue, real_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : bit
   ) is begin
@@ -323,16 +290,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return bit is begin
     check_type(queue, vhdl_bit);
     return decode(pop_fix_string(queue, bit_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : std_ulogic
   ) is begin
@@ -340,16 +305,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return std_ulogic is begin
     check_type(queue, ieee_std_ulogic);
     return decode(pop_fix_string(queue, std_ulogic_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : severity_level
   ) is begin
@@ -357,16 +320,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return severity_level is begin
     check_type(queue, vhdl_severity_level);
     return decode(pop_fix_string(queue, severity_level_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : file_open_status
   ) is begin
@@ -374,16 +335,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return file_open_status is begin
     check_type(queue, vhdl_file_open_status);
     return decode(pop_fix_string(queue, file_open_status_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : file_open_kind
   ) is begin
@@ -391,16 +350,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return file_open_kind is begin
     check_type(queue, vhdl_file_open_kind);
     return decode(pop_fix_string(queue, file_open_kind_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : bit_vector
   ) is begin
@@ -408,16 +365,14 @@ package body queue_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return bit_vector is begin
     check_type(queue, vhdl_bit_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : std_ulogic_vector
   ) is begin
@@ -425,16 +380,14 @@ package body queue_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return std_ulogic_vector is begin
     check_type(queue, vhdl_std_ulogic_vector);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : complex
   ) is begin
@@ -442,16 +395,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return complex is begin
     check_type(queue, ieee_complex);
     return decode(pop_fix_string(queue, complex_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : complex_polar
   ) is begin
@@ -459,16 +410,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return complex_polar is begin
     check_type(queue, ieee_complex_polar);
     return decode(pop_fix_string(queue, complex_polar_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ieee.numeric_bit.unsigned
   ) is begin
@@ -476,16 +425,14 @@ package body queue_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ieee.numeric_bit.unsigned is begin
     check_type(queue, ieee_numeric_bit_unsigned);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ieee.numeric_bit.signed
   ) is begin
@@ -493,16 +440,14 @@ package body queue_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ieee.numeric_bit.signed is begin
     check_type(queue, ieee_numeric_bit_signed);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ieee.numeric_std.unsigned
   ) is begin
@@ -510,16 +455,14 @@ package body queue_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ieee.numeric_std.unsigned is begin
     check_type(queue, ieee_numeric_std_unsigned);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ieee.numeric_std.signed
   ) is begin
@@ -527,16 +470,14 @@ package body queue_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ieee.numeric_std.signed is begin
     check_type(queue, ieee_numeric_std_signed);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : string
   ) is begin
@@ -544,16 +485,14 @@ package body queue_pkg is
     push_variable_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return string is begin
     check_type(queue, vhdl_string);
     return decode(pop_variable_string(queue));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : time
   ) is begin
@@ -561,16 +500,14 @@ package body queue_pkg is
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return time is begin
     check_type(queue, vhdl_time);
     return decode(pop_fix_string(queue, time_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     variable value : inout integer_vector_ptr_t
   ) is begin
@@ -579,31 +516,27 @@ package body queue_pkg is
     value := null_ptr;
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return integer_vector_ptr_t is begin
     check_type(queue, vunit_integer_vector_ptr_t);
     return decode(pop_fix_string(queue, integer_vector_ptr_t_code_length));
   end;
 
-  procedure
-  unsafe_push(
+  procedure unsafe_push (
     queue : queue_t;
     value : integer_vector_ptr_t
   ) is begin
     push_fix_string(queue, encode(value));
   end;
 
-  impure function
-  unsafe_pop(
+  impure function unsafe_pop (
     queue : queue_t
   ) return integer_vector_ptr_t is begin
     return decode(pop_fix_string(queue, integer_vector_ptr_t_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     variable value : inout string_ptr_t
   ) is begin
@@ -612,16 +545,14 @@ package body queue_pkg is
     value := null_string_ptr;
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return string_ptr_t is begin
     check_type(queue, vunit_string_ptr_t);
     return decode(pop_fix_string(queue, string_ptr_t_code_length));
   end;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     variable value : inout queue_t
   ) is begin
@@ -630,16 +561,14 @@ package body queue_pkg is
     value := null_queue;
   end;
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return queue_t is begin
     check_type(queue, vunit_queue_t);
     return decode(pop_fix_string(queue, queue_t_code_length));
   end;
 
-  procedure
-  push_ref(
+  procedure push_ref (
     constant queue : queue_t;
     value : inout integer_array_t
   ) is begin
@@ -656,23 +585,20 @@ package body queue_pkg is
     value := null_integer_array;
   end;
 
-  impure function
-  pop_ref(
+  impure function pop_ref (
     queue : queue_t
-  ) return integer_array_t is
-    variable result : integer_array_t;
-  begin
+  ) return integer_array_t is begin
     check_type(queue, vunit_integer_array_t);
-    result.length      := unsafe_pop(queue);
-    result.width       := unsafe_pop(queue);
-    result.height      := unsafe_pop(queue);
-    result.depth       := unsafe_pop(queue);
-    result.bit_width   := unsafe_pop(queue);
-    result.is_signed   := unsafe_pop(queue);
-    result.lower_limit := unsafe_pop(queue);
-    result.upper_limit := unsafe_pop(queue);
-    result.data        := unsafe_pop(queue);
-
-    return result;
+    return (
+      length      => unsafe_pop(queue),
+      width       => unsafe_pop(queue),
+      height      => unsafe_pop(queue),
+      depth       => unsafe_pop(queue),
+      bit_width   => unsafe_pop(queue),
+      is_signed   => unsafe_pop(queue),
+      lower_limit => unsafe_pop(queue),
+      upper_limit => unsafe_pop(queue),
+      data        => unsafe_pop(queue)
+    );
   end;
 end package body;

--- a/vunit/vhdl/data_types/src/queue_pkg.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg.vhd
@@ -16,362 +16,310 @@ use work.integer_array_pkg.all;
 package queue_pkg is
   type queue_t is record
     p_meta : integer_vector_ptr_t;
-    data : string_ptr_t;
+    data   : string_ptr_t;
   end record;
   type queue_vec_t is array(integer range <>) of queue_t;
   constant null_queue : queue_t := (p_meta => null_ptr, data => null_string_ptr);
 
-  impure function
-  new_queue
+  impure function new_queue
   return queue_t;
 
   -- Returns the length of the queue in bytes
-  impure function
-  length(
+  impure function length (
     queue : queue_t
   ) return natural;
 
-  impure function
-  is_empty(
+  impure function is_empty (
     queue : queue_t
   ) return boolean;
 
-  procedure
-  flush(
+  procedure flush (
     queue : queue_t
   );
 
-  impure function
-  copy(
+  impure function copy (
     queue : queue_t
   ) return queue_t;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : integer
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return integer;
 
   alias push_integer is push[queue_t, integer];
   alias pop_integer is pop[queue_t return integer];
 
-  procedure
-  push_byte(
+  procedure push_byte (
     queue : queue_t;
     value : natural range 0 to 255
   );
 
-  impure function
-  pop_byte(
+  impure function pop_byte (
     queue : queue_t
   ) return integer;
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : character
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return character;
 
   alias push_character is push[queue_t, character];
   alias pop_character is pop[queue_t return character];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : boolean
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return boolean;
 
   alias push_boolean is push[queue_t, boolean];
   alias pop_boolean is pop[queue_t return boolean];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : real
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return real;
 
   alias push_real is push[queue_t, real];
   alias pop_real is pop[queue_t return real];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : bit
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return bit;
 
   alias push_bit is push[queue_t, bit];
   alias pop_bit is pop[queue_t return bit];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : std_ulogic
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return std_ulogic;
 
   alias push_std_ulogic is push[queue_t, std_ulogic];
   alias pop_std_ulogic is pop[queue_t return std_ulogic];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : severity_level
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return severity_level;
 
   alias push_severity_level is push[queue_t, severity_level];
   alias pop_severity_level is pop[queue_t return severity_level];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : file_open_status
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return file_open_status;
 
   alias push_file_open_status is push[queue_t, file_open_status];
   alias pop_file_open_status is pop[queue_t return file_open_status];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : file_open_kind
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return file_open_kind;
 
   alias push_file_open_kind is push[queue_t, file_open_kind];
   alias pop_file_open_kind is pop[queue_t return file_open_kind];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : bit_vector
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return bit_vector;
 
   alias push_bit_vector is push[queue_t, bit_vector];
   alias pop_bit_vector is pop[queue_t return bit_vector];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : std_ulogic_vector
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return std_ulogic_vector;
 
   alias push_std_ulogic_vector is push[queue_t, std_ulogic_vector];
   alias pop_std_ulogic_vector is pop[queue_t return std_ulogic_vector];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : complex
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return complex;
 
   alias push_complex is push[queue_t, complex];
   alias pop_complex is pop[queue_t return complex];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : complex_polar
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return complex_polar;
 
   alias push_complex_polar is push[queue_t, complex_polar];
   alias pop_complex_polar is pop[queue_t return complex_polar];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ieee.numeric_bit.unsigned
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ieee.numeric_bit.unsigned;
 
   alias push_numeric_bit_unsigned is push[queue_t, ieee.numeric_bit.unsigned];
   alias pop_numeric_bit_unsigned is pop[queue_t return ieee.numeric_bit.unsigned];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ieee.numeric_bit.signed
   );
 
-  impure function pop(
+  impure function pop (
     queue : queue_t
   ) return ieee.numeric_bit.signed;
 
   alias push_numeric_bit_signed is push[queue_t, ieee.numeric_bit.signed];
   alias pop_numeric_bit_signed is pop[queue_t return ieee.numeric_bit.signed];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ieee.numeric_std.unsigned
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ieee.numeric_std.unsigned;
 
   alias push_numeric_std_unsigned is push[queue_t, ieee.numeric_std.unsigned];
   alias pop_numeric_std_unsigned is pop[queue_t return ieee.numeric_std.unsigned];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : ieee.numeric_std.signed
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return ieee.numeric_std.signed;
 
   alias push_numeric_std_signed is push[queue_t, ieee.numeric_std.signed];
   alias pop_numeric_std_signed is pop[queue_t return ieee.numeric_std.signed];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : string
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return string;
 
   alias push_string is push[queue_t, string];
   alias pop_string is pop[queue_t return string];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     value : time
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return time;
 
   alias push_time is push[queue_t, time];
   alias pop_time is pop[queue_t return time];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     variable value : inout integer_vector_ptr_t
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return integer_vector_ptr_t;
 
   alias push_integer_vector_ptr_ref is push[queue_t, integer_vector_ptr_t];
   alias pop_integer_vector_ptr_ref is pop[queue_t return integer_vector_ptr_t];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     variable value : inout string_ptr_t
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return string_ptr_t;
 
   alias push_string_ptr_ref is push[queue_t, string_ptr_t];
   alias pop_string_ptr_ref is pop[queue_t return string_ptr_t];
 
-  procedure
-  push(
+  procedure push (
     queue : queue_t;
     variable value : inout queue_t
   );
 
-  impure function
-  pop(
+  impure function pop (
     queue : queue_t
   ) return queue_t;
 
   alias push_queue_ref is push[queue_t, queue_t];
   alias pop_queue_ref is pop[queue_t return queue_t];
 
-  procedure
-  push_ref(
+  procedure push_ref (
     constant queue : queue_t;
     value : inout integer_array_t
   );
 
-  impure function
-  pop_ref(
+  impure function pop_ref (
     queue : queue_t
   ) return integer_array_t;
 
@@ -388,18 +336,15 @@ package queue_pkg is
     vhdl_real_vector, vhdl_time_vector, ieee_ufixed, ieee_sfixed, ieee_float
   );
 
-  function
-  encode(
+  function encode (
     data : queue_t
   ) return string;
 
-  function
-  decode(
+  function decode (
     code : string
   ) return queue_t;
 
-  procedure
-  decode(
+  procedure decode (
     constant code   : string;
     variable index  : inout positive;
     variable result : out queue_t
@@ -408,48 +353,40 @@ package queue_pkg is
   alias encode_queue_t is encode[queue_t return string];
   alias decode_queue_t is decode[string return queue_t];
 
-  procedure
-  push_type(
+  procedure push_type (
     queue        : queue_t;
     element_type : queue_element_type_t
   );
 
-  procedure
-  check_type(
+  procedure check_type (
     queue        : queue_t;
     element_type : queue_element_type_t
   );
 
-  procedure
-  unsafe_push(
+  procedure unsafe_push (
     queue : queue_t;
     value : character
   );
 
-  impure function
-  unsafe_pop(
+  impure function unsafe_pop (
     queue : queue_t
   ) return character;
 
-  procedure
-  push_variable_string(
+  procedure push_variable_string (
     queue : queue_t;
     value : string
   );
 
-  impure function
-  pop_variable_string(
+  impure function pop_variable_string (
     queue : queue_t
   ) return string;
 
-  procedure
-  push_fix_string(
+  procedure push_fix_string (
     queue : queue_t;
     value : string
   );
 
-  impure function
-  pop_fix_string(
+  impure function pop_fix_string (
     queue  : queue_t;
     length : natural
   ) return string;

--- a/vunit/vhdl/data_types/src/queue_pkg.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg.vhd
@@ -14,7 +14,6 @@ use work.string_ptr_pkg.all;
 use work.integer_array_pkg.all;
 
 package queue_pkg is
-
   type queue_t is record
     p_meta : integer_vector_ptr_t;
     data : string_ptr_t;
@@ -22,129 +21,360 @@ package queue_pkg is
   type queue_vec_t is array(integer range <>) of queue_t;
   constant null_queue : queue_t := (p_meta => null_ptr, data => null_string_ptr);
 
-  impure function new_queue return queue_t;
+  impure function
+  new_queue
+  return queue_t;
 
   -- Returns the length of the queue in bytes
-  impure function length(queue : queue_t) return natural;
-  impure function is_empty(queue : queue_t) return boolean;
-  procedure flush(queue : queue_t);
-  impure function copy(queue : queue_t) return queue_t;
+  impure function
+  length(
+    queue : queue_t
+  ) return natural;
 
-  procedure push(queue : queue_t; value : integer);
-  impure function pop(queue : queue_t) return integer;
+  impure function
+  is_empty(
+    queue : queue_t
+  ) return boolean;
+
+  procedure
+  flush(
+    queue : queue_t
+  );
+
+  impure function
+  copy(
+    queue : queue_t
+  ) return queue_t;
+
+  procedure
+  push(
+    queue : queue_t;
+    value : integer
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return integer;
+
   alias push_integer is push[queue_t, integer];
   alias pop_integer is pop[queue_t return integer];
 
-  procedure push_byte(queue : queue_t; value : natural range 0 to 255);
-  impure function pop_byte(queue : queue_t) return integer;
+  procedure
+  push_byte(
+    queue : queue_t;
+    value : natural range 0 to 255
+  );
 
-  procedure push(queue : queue_t; value : character);
-  impure function pop(queue : queue_t) return character;
+  impure function
+  pop_byte(
+    queue : queue_t
+  ) return integer;
+
+  procedure
+  push(
+    queue : queue_t;
+    value : character
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return character;
+
   alias push_character is push[queue_t, character];
   alias pop_character is pop[queue_t return character];
 
-  procedure push(queue : queue_t; value : boolean);
-  impure function pop(queue : queue_t) return boolean;
+  procedure
+  push(
+    queue : queue_t;
+    value : boolean
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return boolean;
+
   alias push_boolean is push[queue_t, boolean];
   alias pop_boolean is pop[queue_t return boolean];
 
-  procedure push(queue : queue_t; value : real);
-  impure function pop(queue : queue_t) return real;
+  procedure
+  push(
+    queue : queue_t;
+    value : real
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return real;
+
   alias push_real is push[queue_t, real];
   alias pop_real is pop[queue_t return real];
 
-  procedure push(queue : queue_t; value : bit);
-  impure function pop(queue : queue_t) return bit;
+  procedure
+  push(
+    queue : queue_t;
+    value : bit
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return bit;
+
   alias push_bit is push[queue_t, bit];
   alias pop_bit is pop[queue_t return bit];
 
-  procedure push(queue : queue_t; value : std_ulogic);
-  impure function pop(queue : queue_t) return std_ulogic;
+  procedure
+  push(
+    queue : queue_t;
+    value : std_ulogic
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return std_ulogic;
+
   alias push_std_ulogic is push[queue_t, std_ulogic];
   alias pop_std_ulogic is pop[queue_t return std_ulogic];
 
-  procedure push(queue : queue_t; value : severity_level);
-  impure function pop(queue : queue_t) return severity_level;
+  procedure
+  push(
+    queue : queue_t;
+    value : severity_level
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return severity_level;
+
   alias push_severity_level is push[queue_t, severity_level];
   alias pop_severity_level is pop[queue_t return severity_level];
 
-  procedure push(queue : queue_t; value : file_open_status);
-  impure function pop(queue : queue_t) return file_open_status;
+  procedure
+  push(
+    queue : queue_t;
+    value : file_open_status
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return file_open_status;
+
   alias push_file_open_status is push[queue_t, file_open_status];
   alias pop_file_open_status is pop[queue_t return file_open_status];
 
-  procedure push(queue : queue_t; value : file_open_kind);
-  impure function pop(queue : queue_t) return file_open_kind;
+  procedure
+  push(
+    queue : queue_t;
+    value : file_open_kind
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return file_open_kind;
+
   alias push_file_open_kind is push[queue_t, file_open_kind];
   alias pop_file_open_kind is pop[queue_t return file_open_kind];
 
-  procedure push(queue : queue_t; value : bit_vector);
-  impure function pop(queue : queue_t) return bit_vector;
+  procedure
+  push(
+    queue : queue_t;
+    value : bit_vector
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return bit_vector;
+
   alias push_bit_vector is push[queue_t, bit_vector];
   alias pop_bit_vector is pop[queue_t return bit_vector];
 
-  procedure push(queue : queue_t; value : std_ulogic_vector);
-  impure function pop(queue : queue_t) return std_ulogic_vector;
+  procedure
+  push(
+    queue : queue_t;
+    value : std_ulogic_vector
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return std_ulogic_vector;
+
   alias push_std_ulogic_vector is push[queue_t, std_ulogic_vector];
   alias pop_std_ulogic_vector is pop[queue_t return std_ulogic_vector];
 
-  procedure push(queue : queue_t; value : complex);
-  impure function pop(queue : queue_t) return complex;
+  procedure
+  push(
+    queue : queue_t;
+    value : complex
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return complex;
+
   alias push_complex is push[queue_t, complex];
   alias pop_complex is pop[queue_t return complex];
 
-  procedure push(queue : queue_t; value : complex_polar);
-  impure function pop(queue : queue_t) return complex_polar;
+  procedure
+  push(
+    queue : queue_t;
+    value : complex_polar
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return complex_polar;
+
   alias push_complex_polar is push[queue_t, complex_polar];
   alias pop_complex_polar is pop[queue_t return complex_polar];
 
-  procedure push(queue : queue_t; value : ieee.numeric_bit.unsigned);
-  impure function pop(queue : queue_t) return ieee.numeric_bit.unsigned;
+  procedure
+  push(
+    queue : queue_t;
+    value : ieee.numeric_bit.unsigned
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return ieee.numeric_bit.unsigned;
+
   alias push_numeric_bit_unsigned is push[queue_t, ieee.numeric_bit.unsigned];
   alias pop_numeric_bit_unsigned is pop[queue_t return ieee.numeric_bit.unsigned];
 
-  procedure push(queue : queue_t; value : ieee.numeric_bit.signed);
-  impure function pop(queue : queue_t) return ieee.numeric_bit.signed;
+  procedure
+  push(
+    queue : queue_t;
+    value : ieee.numeric_bit.signed
+  );
+
+  impure function pop(
+    queue : queue_t
+  ) return ieee.numeric_bit.signed;
+
   alias push_numeric_bit_signed is push[queue_t, ieee.numeric_bit.signed];
   alias pop_numeric_bit_signed is pop[queue_t return ieee.numeric_bit.signed];
 
-  procedure push(queue : queue_t; value : ieee.numeric_std.unsigned);
-  impure function pop(queue : queue_t) return ieee.numeric_std.unsigned;
+  procedure
+  push(
+    queue : queue_t;
+    value : ieee.numeric_std.unsigned
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return ieee.numeric_std.unsigned;
+
   alias push_numeric_std_unsigned is push[queue_t, ieee.numeric_std.unsigned];
   alias pop_numeric_std_unsigned is pop[queue_t return ieee.numeric_std.unsigned];
 
-  procedure push(queue : queue_t; value : ieee.numeric_std.signed);
-  impure function pop(queue : queue_t) return ieee.numeric_std.signed;
+  procedure
+  push(
+    queue : queue_t;
+    value : ieee.numeric_std.signed
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return ieee.numeric_std.signed;
+
   alias push_numeric_std_signed is push[queue_t, ieee.numeric_std.signed];
   alias pop_numeric_std_signed is pop[queue_t return ieee.numeric_std.signed];
 
-  procedure push(queue : queue_t; value : string);
-  impure function pop(queue : queue_t) return string;
+  procedure
+  push(
+    queue : queue_t;
+    value : string
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return string;
+
   alias push_string is push[queue_t, string];
   alias pop_string is pop[queue_t return string];
 
-  procedure push(queue : queue_t; value : time);
-  impure function pop(queue : queue_t) return time;
+  procedure
+  push(
+    queue : queue_t;
+    value : time
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return time;
+
   alias push_time is push[queue_t, time];
   alias pop_time is pop[queue_t return time];
 
-  procedure push(queue : queue_t; variable value : inout integer_vector_ptr_t);
-  impure function pop(queue : queue_t) return integer_vector_ptr_t;
+  procedure
+  push(
+    queue : queue_t;
+    variable value : inout integer_vector_ptr_t
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return integer_vector_ptr_t;
+
   alias push_integer_vector_ptr_ref is push[queue_t, integer_vector_ptr_t];
   alias pop_integer_vector_ptr_ref is pop[queue_t return integer_vector_ptr_t];
 
-  procedure push(queue : queue_t; variable value : inout string_ptr_t);
-  impure function pop(queue : queue_t) return string_ptr_t;
+  procedure
+  push(
+    queue : queue_t;
+    variable value : inout string_ptr_t
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return string_ptr_t;
+
   alias push_string_ptr_ref is push[queue_t, string_ptr_t];
   alias pop_string_ptr_ref is pop[queue_t return string_ptr_t];
 
-  procedure push(queue : queue_t; variable value : inout queue_t);
-  impure function pop(queue : queue_t) return queue_t;
+  procedure
+  push(
+    queue : queue_t;
+    variable value : inout queue_t
+  );
+
+  impure function
+  pop(
+    queue : queue_t
+  ) return queue_t;
+
   alias push_queue_ref is push[queue_t, queue_t];
   alias pop_queue_ref is pop[queue_t return queue_t];
 
-  procedure push_ref(constant queue : queue_t; value : inout integer_array_t);
-  impure function pop_ref(queue : queue_t) return integer_array_t;
+  procedure
+  push_ref(
+    constant queue : queue_t;
+    value : inout integer_array_t
+  );
+
+  impure function
+  pop_ref(
+    queue : queue_t
+  ) return integer_array_t;
+
   alias push_integer_array_t_ref is push_ref[queue_t, integer_array_t];
   alias pop_integer_array_t_ref is pop_ref[queue_t return integer_array_t];
 
@@ -158,18 +388,69 @@ package queue_pkg is
     vhdl_real_vector, vhdl_time_vector, ieee_ufixed, ieee_sfixed, ieee_float
   );
 
-  function encode(data : queue_t) return string;
-  function decode(code : string) return queue_t;
-  procedure decode (constant code : string; variable index : inout positive; variable result : out queue_t);
+  function
+  encode(
+    data : queue_t
+  ) return string;
+
+  function
+  decode(
+    code : string
+  ) return queue_t;
+
+  procedure
+  decode(
+    constant code   : string;
+    variable index  : inout positive;
+    variable result : out queue_t
+  );
+
   alias encode_queue_t is encode[queue_t return string];
   alias decode_queue_t is decode[string return queue_t];
-  procedure push_type(queue : queue_t; element_type : queue_element_type_t);
-  procedure check_type(queue : queue_t; element_type : queue_element_type_t);
-  procedure unsafe_push(queue : queue_t; value : character);
-  impure function unsafe_pop(queue : queue_t) return character;
-  procedure push_variable_string(queue : queue_t; value : string);
-  impure function pop_variable_string(queue : queue_t) return string;
-  procedure push_fix_string(queue : queue_t; value : string);
-  impure function pop_fix_string(queue : queue_t; length : natural) return string;
 
+  procedure
+  push_type(
+    queue        : queue_t;
+    element_type : queue_element_type_t
+  );
+
+  procedure
+  check_type(
+    queue        : queue_t;
+    element_type : queue_element_type_t
+  );
+
+  procedure
+  unsafe_push(
+    queue : queue_t;
+    value : character
+  );
+
+  impure function
+  unsafe_pop(
+    queue : queue_t
+  ) return character;
+
+  procedure
+  push_variable_string(
+    queue : queue_t;
+    value : string
+  );
+
+  impure function
+  pop_variable_string(
+    queue : queue_t
+  ) return string;
+
+  procedure
+  push_fix_string(
+    queue : queue_t;
+    value : string
+  );
+
+  impure function
+  pop_fix_string(
+    queue  : queue_t;
+    length : natural
+  ) return string;
 end package;

--- a/vunit/vhdl/data_types/src/queue_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/queue_pool_pkg.vhd
@@ -17,45 +17,42 @@ package queue_pool_pkg is
     index_pool => null_integer_vector_ptr_pool,
     data_pool => null_string_ptr_pool);
 
-  impure function
-  new_queue_pool
+  impure function new_queue_pool
   return queue_pool_t;
 
-  impure function
-  new_queue(
+  impure function new_queue (
     pool : queue_pool_t
   ) return queue_t;
 
-  procedure
-  recycle(
+  procedure recycle (
     pool : queue_pool_t;
     variable queue : inout queue_t
   );
-
 end package;
 
 package body queue_pool_pkg is
-  impure function
-  new_queue_pool
+  impure function new_queue_pool
   return queue_pool_t is begin
-    return (index_pool => new_integer_vector_ptr_pool,
-            data_pool => new_string_ptr_pool);
+    return (
+      index_pool => new_integer_vector_ptr_pool,
+      data_pool  => new_string_ptr_pool
+    );
   end;
 
-  impure function
-  new_queue(
+  impure function new_queue (
     pool : queue_pool_t
   ) return queue_t is
     variable queue : queue_t;
   begin
-    queue := (p_meta => new_integer_vector_ptr(pool.index_pool, 2),
-              data => new_string_ptr(pool.data_pool, 0));
+    queue := (
+      p_meta => new_integer_vector_ptr(pool.index_pool, 2),
+      data => new_string_ptr(pool.data_pool, 0)
+    );
     flush(queue);
     return queue;
   end;
 
-  procedure
-  recycle(
+  procedure recycle (
     pool : queue_pool_t;
     variable queue : inout queue_t
   ) is begin

--- a/vunit/vhdl/data_types/src/queue_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/queue_pool_pkg.vhd
@@ -17,20 +17,35 @@ package queue_pool_pkg is
     index_pool => null_integer_vector_ptr_pool,
     data_pool => null_string_ptr_pool);
 
-  impure function new_queue_pool return queue_pool_t;
-  impure function new_queue(pool : queue_pool_t) return queue_t;
-  procedure recycle(pool : queue_pool_t; variable queue : inout queue_t);
+  impure function
+  new_queue_pool
+  return queue_pool_t;
+
+  impure function
+  new_queue(
+    pool : queue_pool_t
+  ) return queue_t;
+
+  procedure
+  recycle(
+    pool : queue_pool_t;
+    variable queue : inout queue_t
+  );
 
 end package;
 
 package body queue_pool_pkg is
-  impure function new_queue_pool return queue_pool_t is
-  begin
+  impure function
+  new_queue_pool
+  return queue_pool_t is begin
     return (index_pool => new_integer_vector_ptr_pool,
             data_pool => new_string_ptr_pool);
   end;
 
-  impure function new_queue(pool : queue_pool_t) return queue_t is
+  impure function
+  new_queue(
+    pool : queue_pool_t
+  ) return queue_t is
     variable queue : queue_t;
   begin
     queue := (p_meta => new_integer_vector_ptr(pool.index_pool, 2),
@@ -39,10 +54,12 @@ package body queue_pool_pkg is
     return queue;
   end;
 
-  procedure recycle(pool : queue_pool_t; variable queue : inout queue_t) is
-  begin
+  procedure
+  recycle(
+    pool : queue_pool_t;
+    variable queue : inout queue_t
+  ) is begin
     recycle(pool.index_pool, queue.p_meta);
     recycle(pool.data_pool, queue.data);
   end;
-
 end package body;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -5,10 +5,6 @@
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 package body string_ptr_pkg is
-  type string_access_t is access string;
-  type string_access_vector_t is array (natural range <>) of string_access_t;
-  type string_access_vector_access_t is access string_access_vector_t;
-
   type string_ptr_storage_t is protected
     impure function
     new_string_ptr(

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -24,14 +24,14 @@ package body string_ptr_pkg is
     procedure
     set(
       ref   : natural;
-      index : integer;
+      index : natural;
       value : val_t
     );
 
     impure function
     get(
       ref   : natural;
-      index : integer
+      index : natural
     ) return val_t;
 
     procedure
@@ -104,7 +104,7 @@ package body string_ptr_pkg is
     procedure
     set(
       ref   : natural;
-      index : integer;
+      index : natural;
       value : val_t
     ) is begin
       ptrs(ref)(index) := value;
@@ -113,7 +113,7 @@ package body string_ptr_pkg is
     impure function
     get(
       ref   : natural;
-      index : integer
+      index : natural
     ) return val_t is begin
       return ptrs(ref)(index);
     end;
@@ -229,7 +229,7 @@ package body string_ptr_pkg is
   procedure
   set(
     ptr   : ptr_t;
-    index : integer;
+    index : natural;
     value : val_t
   ) is begin
     string_ptr_storage.set(ptr.ref, index, value);
@@ -238,7 +238,7 @@ package body string_ptr_pkg is
   impure function
   get(
     ptr : ptr_t;
-    index : integer
+    index : natural
   ) return val_t is begin
     return string_ptr_storage.get(ptr.ref, index);
   end;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -10,22 +10,67 @@ package body string_ptr_pkg is
   type string_access_vector_access_t is access string_access_vector_t;
 
   type string_ptr_storage_t is protected
-    impure function new_string_ptr(length : natural := 0) return string_ptr_t;
-    procedure deallocate(ptr : string_ptr_t);
-    impure function length(ptr : string_ptr_t) return integer;
-    procedure set(ptr : string_ptr_t; index : integer; value : character);
-    impure function get(ptr : string_ptr_t; index : integer) return character;
-    procedure reallocate(ptr : string_ptr_t; length : natural);
-    procedure reallocate(ptr : string_ptr_t; value : string);
-    procedure resize(ptr : string_ptr_t; length : natural; drop : natural := 0);
-    impure function to_string(ptr : string_ptr_t) return string;
+    impure function
+    new_string_ptr(
+      length : natural := 0
+    ) return string_ptr_t;
+
+    procedure
+    deallocate(
+      ptr : string_ptr_t
+    );
+
+    impure function
+    length(
+      ptr : string_ptr_t
+    ) return integer;
+
+    procedure
+    set(
+      ptr   : string_ptr_t;
+      index : integer;
+      value : character
+    );
+
+    impure function
+    get(
+      ptr   : string_ptr_t;
+      index : integer
+    ) return character;
+
+    procedure
+    reallocate(
+      ptr    : string_ptr_t;
+      length : natural
+    );
+
+    procedure
+    reallocate(
+      ptr   : string_ptr_t;
+      value : string
+    );
+
+    procedure
+    resize(
+      ptr    : string_ptr_t;
+      length : natural;
+      drop   : natural := 0
+    );
+
+    impure function
+    to_string(
+      ptr : string_ptr_t
+    ) return string;
   end protected;
 
   type string_ptr_storage_t is protected body
     variable current_index : integer := 0;
     variable ptrs : string_access_vector_access_t := null;
 
-    impure function new_string_ptr(length : natural := 0) return string_ptr_t is
+    impure function
+    new_string_ptr(
+      length : natural := 0
+    ) return string_ptr_t is
       variable old_ptrs : string_access_vector_access_t;
       variable retval : string_ptr_t := (index => current_index);
     begin
@@ -46,45 +91,69 @@ package body string_ptr_pkg is
       ptrs(current_index) := new string'(1 to length => character'low);
       current_index := current_index + 1;
       return retval;
-    end function;
+    end;
 
-    procedure deallocate(ptr : string_ptr_t) is
-    begin
+    procedure
+    deallocate(
+      ptr : string_ptr_t
+    ) is begin
       deallocate(ptrs(ptr.index));
       ptrs(ptr.index) := null;
-    end procedure;
+    end;
 
-    impure function length(ptr : string_ptr_t) return integer is
-    begin
+    impure function
+    length(
+      ptr : string_ptr_t
+    ) return integer is begin
       return ptrs(ptr.index)'length;
-    end function;
+    end;
 
-    procedure set(ptr : string_ptr_t; index : integer; value : character) is
-    begin
+    procedure
+    set(
+      ptr   : string_ptr_t;
+      index : integer;
+      value : character
+    ) is begin
       ptrs(ptr.index)(index) := value;
-    end procedure;
+    end;
 
-    impure function get(ptr : string_ptr_t; index : integer) return character is
-    begin
+    impure function
+    get(
+      ptr   : string_ptr_t;
+      index : integer
+    ) return character is begin
       return ptrs(ptr.index)(index);
-    end function;
+    end;
 
-    procedure reallocate(ptr : string_ptr_t; length : natural) is
+    procedure
+    reallocate(
+      ptr    : string_ptr_t;
+      length : natural
+    ) is
       variable old_ptr, new_ptr : string_access_t;
     begin
       deallocate(ptrs(ptr.index));
       ptrs(ptr.index) := new string'(1 to length => character'low);
-    end procedure;
+    end;
 
-    procedure reallocate(ptr : string_ptr_t; value : string) is
+    procedure
+    reallocate(
+      ptr   : string_ptr_t;
+      value : string
+    ) is
       variable old_ptr, new_ptr : string_access_t;
       variable n_value : string(1 to value'length) := value;
     begin
       deallocate(ptrs(ptr.index));
       ptrs(ptr.index) := new string'(n_value);
-    end procedure;
+    end;
 
-    procedure resize(ptr : string_ptr_t; length : natural; drop : natural := 0) is
+    procedure
+    resize(
+      ptr    : string_ptr_t;
+      length : natural;
+      drop   : natural := 0
+    ) is
       variable old_ptr, new_ptr : string_access_t;
       variable min_length : natural := length;
     begin
@@ -101,10 +170,12 @@ package body string_ptr_pkg is
 
       ptrs(ptr.index) := new_ptr;
       deallocate(old_ptr);
-    end procedure;
+    end;
 
-    impure function to_string(ptr : string_ptr_t) return string is
-    begin
+    impure function
+    to_string(
+      ptr : string_ptr_t
+    ) return string is begin
       return ptrs(ptr.index).all;
     end;
 
@@ -112,23 +183,32 @@ package body string_ptr_pkg is
 
   shared variable string_ptr_storage : string_ptr_storage_t;
 
-  function to_integer(value : string_ptr_t) return integer is
-  begin
+  function
+  to_integer(
+    value : string_ptr_t
+  ) return integer is begin
     return value.index;
-  end function;
+  end;
 
-  impure function to_string_ptr(value : integer) return string_ptr_t is
-  begin
+  impure function
+  to_string_ptr(
+    value : integer
+  ) return string_ptr_t is begin
     -- @TODO maybe assert that the index is valid
     return (index => value);
-  end function;
+  end;
 
-  impure function new_string_ptr(length : natural := 0) return string_ptr_t is
-  begin
+  impure function
+  new_string_ptr(
+    length : natural := 0
+  ) return string_ptr_t is begin
     return string_ptr_storage.new_string_ptr(length);
-  end function;
+  end;
 
-  impure function new_string_ptr(value : string) return string_ptr_t is
+  impure function
+  new_string_ptr(
+    value : string
+  ) return string_ptr_t is
     variable result : string_ptr_t := new_string_ptr(value'length);
     variable n_value : string(1 to value'length) := value;
   begin
@@ -136,64 +216,93 @@ package body string_ptr_pkg is
       set(result, i, n_value(i));
     end loop;
     return result;
-  end function;
+  end;
 
-  procedure deallocate(ptr : string_ptr_t) is
+  procedure
+  deallocate(
+    ptr : string_ptr_t
+  ) is
   begin
     string_ptr_storage.deallocate(ptr);
-  end procedure;
+  end;
 
-  impure function length(ptr : string_ptr_t) return integer is
-  begin
+  impure function
+  length(
+    ptr : string_ptr_t
+  ) return integer is begin
     return string_ptr_storage.length(ptr);
-  end function;
+  end;
 
-  procedure set(ptr : string_ptr_t; index : integer; value : character) is
-  begin
+  procedure
+  set(
+    ptr   : string_ptr_t;
+    index : integer;
+    value : character
+  ) is begin
     string_ptr_storage.set(ptr, index, value);
-  end procedure;
+  end;
 
-  impure function get(ptr : string_ptr_t; index : integer) return character is
-  begin
+  impure function
+  get(
+    ptr : string_ptr_t;
+    index : integer
+  ) return character is begin
     return string_ptr_storage.get(ptr, index);
-  end function;
+  end;
 
-  procedure reallocate(ptr : string_ptr_t; length : natural) is
-  begin
+  procedure
+  reallocate(
+    ptr : string_ptr_t;
+    length : natural
+  ) is begin
     string_ptr_storage.reallocate(ptr, length);
-  end procedure;
+  end;
 
   procedure reallocate(ptr : string_ptr_t; value : string) is
   begin
     string_ptr_storage.reallocate(ptr, value);
-  end procedure;
+  end;
 
-  procedure resize(ptr : string_ptr_t; length : natural; drop : natural := 0) is
-  begin
+  procedure
+  resize(
+    ptr    : string_ptr_t;
+    length : natural;
+    drop   : natural := 0
+  ) is begin
     string_ptr_storage.resize(ptr, length, drop);
-  end procedure;
+  end;
 
-  impure function to_string(ptr : string_ptr_t) return string is
-  begin
+  impure function
+  to_string(
+    ptr : string_ptr_t
+  ) return string is begin
     return string_ptr_storage.to_string(ptr);
   end;
 
-  function encode(data : string_ptr_t) return string is
-  begin
+  function
+  encode(
+    data : string_ptr_t
+  ) return string is begin
     return encode(data.index);
   end;
 
-  function decode(code : string) return string_ptr_t is
+  function
+  decode(
+    code : string
+  ) return string_ptr_t is
     variable ret_val : string_ptr_t;
     variable index : positive := code'left;
   begin
     decode(code, index, ret_val);
-
     return ret_val;
   end;
 
-  procedure decode (constant code : string; variable index : inout positive; variable result : out string_ptr_t) is
-  begin
+  procedure
+  decode(
+    constant code : string;
+    variable index : inout positive;
+    variable result : out string_ptr_t
+  ) is begin
     decode(code, index, result.index);
   end;
 

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -9,53 +9,53 @@ package body string_ptr_pkg is
     impure function
     new_string_ptr(
       length : natural := 0
-    ) return ptr_t;
+    ) return natural;
 
     procedure
     deallocate(
-      ptr : ptr_t
+      ref : natural
     );
 
     impure function
     length(
-      ptr : ptr_t
+      ref : natural
     ) return integer;
 
     procedure
     set(
-      ptr   : ptr_t;
+      ref   : natural;
       index : integer;
       value : val_t
     );
 
     impure function
     get(
-      ptr   : ptr_t;
+      ref   : natural;
       index : integer
     ) return val_t;
 
     procedure
     reallocate(
-      ptr    : ptr_t;
+      ref    : natural;
       length : natural
     );
 
     procedure
     reallocate(
-      ptr   : ptr_t;
+      ref   : natural;
       value : string
     );
 
     procedure
     resize(
-      ptr    : ptr_t;
+      ref    : natural;
       length : natural;
       drop   : natural := 0
     );
 
     impure function
     to_string(
-      ptr : ptr_t
+      ref : natural
     ) return string;
   end protected;
 
@@ -67,8 +67,7 @@ package body string_ptr_pkg is
     new_string_ptr(
       length : natural := 0
     ) return ptr_t is
-      variable old_ptrs : vava_t;
-      variable retval : ptr_t := (index => current_index);
+      variable old_ptrs : string_access_vector_access_t;
     begin
       if ptrs = null then
         ptrs := new vav_t'(0 => null);
@@ -84,67 +83,67 @@ package body string_ptr_pkg is
       end if;
       ptrs(current_index) := new string'(1 to length => val_t'low);
       current_index := current_index + 1;
-      return retval;
+      return current_index-1;
     end;
 
     procedure
     deallocate(
-      ptr : ptr_t
+      ref : natural
     ) is begin
-      deallocate(ptrs(ptr.index));
-      ptrs(ptr.index) := null;
+      deallocate(ptrs(ref));
+      ptrs(ref) := null;
     end;
 
     impure function
     length(
-      ptr : ptr_t
+      ref : natural
     ) return integer is begin
-      return ptrs(ptr.index)'length;
+      return ptrs(ref)'length;
     end;
 
     procedure
     set(
-      ptr   : ptr_t;
+      ref   : natural;
       index : integer;
       value : val_t
     ) is begin
-      ptrs(ptr.index)(index) := value;
+      ptrs(ref)(index) := value;
     end;
 
     impure function
     get(
-      ptr   : ptr_t;
+      ref   : natural;
       index : integer
     ) return val_t is begin
-      return ptrs(ptr.index)(index);
+      return ptrs(ref)(index);
     end;
 
     procedure
     reallocate(
-      ptr    : ptr_t;
+      ref    : natural;
       length : natural
     ) is
       variable old_ptr, new_ptr : string_access_t;
     begin
-      deallocate(ptrs(ptr.index));
-      ptrs(ptr.index) := new string'(1 to length => val_t'low);
+      deallocate(ptrs(ref));
+      ptrs(ref) := new string'(1 to length => val_t'low);
     end;
 
     procedure
     reallocate(
-      ptr   : ptr_t;
+      ref   : natural;
       value : string
     ) is
       variable old_ptr, new_ptr : string_access_t;
       variable n_value : string(1 to value'length) := value;
     begin
-      deallocate(ptrs(ptr.index));
-      ptrs(ptr.index) := new string'(n_value);
+      deallocate(ptrs(ref));
+      ptrs(ref) := new string'(n_value);
     end;
 
     procedure
     resize(
-      ptr    : ptr_t;
+      ref    : natural;
       length : natural;
       drop   : natural := 0
     ) is
@@ -152,7 +151,7 @@ package body string_ptr_pkg is
       variable min_length : natural := length;
     begin
       new_ptr := new string'(1 to length => val_t'low);
-      old_ptr := ptrs(ptr.index);
+      old_ptr := ptrs(ref);
 
       if min_length > old_ptr'length - drop then
         min_length := old_ptr'length - drop;
@@ -162,15 +161,15 @@ package body string_ptr_pkg is
         new_ptr(i) := old_ptr(drop + i);
       end loop;
 
-      ptrs(ptr.index) := new_ptr;
+      ptrs(ref) := new_ptr;
       deallocate(old_ptr);
     end;
 
     impure function
     to_string(
-      ptr : ptr_t
+      ref : natural
     ) return string is begin
-      return ptrs(ptr.index).all;
+      return ptrs(ref).all;
     end;
 
   end protected body;
@@ -196,7 +195,7 @@ package body string_ptr_pkg is
   new_string_ptr(
     length : natural := 0
   ) return ptr_t is begin
-    return string_ptr_storage.new_string_ptr(length);
+    return (index => string_ptr_storage.new_string_ptr(length));
   end;
 
   impure function
@@ -217,14 +216,14 @@ package body string_ptr_pkg is
     ptr : ptr_t
   ) is
   begin
-    string_ptr_storage.deallocate(ptr);
+    string_ptr_storage.deallocate(ptr.index);
   end;
 
   impure function
   length(
     ptr : ptr_t
   ) return integer is begin
-    return string_ptr_storage.length(ptr);
+    return string_ptr_storage.length(ptr.index);
   end;
 
   procedure
@@ -233,7 +232,7 @@ package body string_ptr_pkg is
     index : integer;
     value : val_t
   ) is begin
-    string_ptr_storage.set(ptr, index, value);
+    string_ptr_storage.set(ptr.index, index, value);
   end;
 
   impure function
@@ -241,7 +240,7 @@ package body string_ptr_pkg is
     ptr : ptr_t;
     index : integer
   ) return val_t is begin
-    return string_ptr_storage.get(ptr, index);
+    return string_ptr_storage.get(ptr.index, index);
   end;
 
   procedure
@@ -249,12 +248,12 @@ package body string_ptr_pkg is
     ptr : ptr_t;
     length : natural
   ) is begin
-    string_ptr_storage.reallocate(ptr, length);
+    string_ptr_storage.reallocate(ptr.index, length);
   end;
 
   procedure reallocate(ptr : ptr_t; value : string) is
   begin
-    string_ptr_storage.reallocate(ptr, value);
+    string_ptr_storage.reallocate(ptr.index, value);
   end;
 
   procedure
@@ -263,14 +262,14 @@ package body string_ptr_pkg is
     length : natural;
     drop   : natural := 0
   ) is begin
-    string_ptr_storage.resize(ptr, length, drop);
+    string_ptr_storage.resize(ptr.index, length, drop);
   end;
 
   impure function
   to_string(
     ptr : ptr_t
   ) return string is begin
-    return string_ptr_storage.to_string(ptr);
+    return string_ptr_storage.to_string(ptr.index);
   end;
 
   function

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -66,7 +66,7 @@ package body string_ptr_pkg is
     impure function
     new_string_ptr(
       length : natural := 0
-    ) return ptr_t is
+    ) return natural is
       variable old_ptrs : string_access_vector_access_t;
     begin
       if ptrs = null then
@@ -180,22 +180,22 @@ package body string_ptr_pkg is
   to_integer(
     value : ptr_t
   ) return integer is begin
-    return value.index;
+    return value.ref;
   end;
 
   impure function
   to_string_ptr(
     value : integer
   ) return ptr_t is begin
-    -- @TODO maybe assert that the index is valid
-    return (index => value);
+    -- @TODO maybe assert that the ref is valid
+    return (ref => value);
   end;
 
   impure function
   new_string_ptr(
     length : natural := 0
   ) return ptr_t is begin
-    return (index => string_ptr_storage.new_string_ptr(length));
+    return (ref => string_ptr_storage.new_string_ptr(length));
   end;
 
   impure function
@@ -216,14 +216,14 @@ package body string_ptr_pkg is
     ptr : ptr_t
   ) is
   begin
-    string_ptr_storage.deallocate(ptr.index);
+    string_ptr_storage.deallocate(ptr.ref);
   end;
 
   impure function
   length(
     ptr : ptr_t
   ) return integer is begin
-    return string_ptr_storage.length(ptr.index);
+    return string_ptr_storage.length(ptr.ref);
   end;
 
   procedure
@@ -232,7 +232,7 @@ package body string_ptr_pkg is
     index : integer;
     value : val_t
   ) is begin
-    string_ptr_storage.set(ptr.index, index, value);
+    string_ptr_storage.set(ptr.ref, index, value);
   end;
 
   impure function
@@ -240,7 +240,7 @@ package body string_ptr_pkg is
     ptr : ptr_t;
     index : integer
   ) return val_t is begin
-    return string_ptr_storage.get(ptr.index, index);
+    return string_ptr_storage.get(ptr.ref, index);
   end;
 
   procedure
@@ -248,12 +248,12 @@ package body string_ptr_pkg is
     ptr : ptr_t;
     length : natural
   ) is begin
-    string_ptr_storage.reallocate(ptr.index, length);
+    string_ptr_storage.reallocate(ptr.ref, length);
   end;
 
   procedure reallocate(ptr : ptr_t; value : string) is
   begin
-    string_ptr_storage.reallocate(ptr.index, value);
+    string_ptr_storage.reallocate(ptr.ref, value);
   end;
 
   procedure
@@ -262,21 +262,21 @@ package body string_ptr_pkg is
     length : natural;
     drop   : natural := 0
   ) is begin
-    string_ptr_storage.resize(ptr.index, length, drop);
+    string_ptr_storage.resize(ptr.ref, length, drop);
   end;
 
   impure function
   to_string(
     ptr : ptr_t
   ) return string is begin
-    return string_ptr_storage.to_string(ptr.index);
+    return string_ptr_storage.to_string(ptr.ref);
   end;
 
   function
   encode(
     data : ptr_t
   ) return string is begin
-    return encode(data.index);
+    return encode(data.ref);
   end;
 
   function
@@ -296,7 +296,7 @@ package body string_ptr_pkg is
     variable index : inout positive;
     variable result : out ptr_t
   ) is begin
-    decode(code, index, result.index);
+    decode(code, index, result.ref);
   end;
 
 end package body;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -13,89 +13,87 @@ package body string_ptr_pkg is
     impure function
     new_string_ptr(
       length : natural := 0
-    ) return string_ptr_t;
+    ) return ptr_t;
 
     procedure
     deallocate(
-      ptr : string_ptr_t
+      ptr : ptr_t
     );
 
     impure function
     length(
-      ptr : string_ptr_t
+      ptr : ptr_t
     ) return integer;
 
     procedure
     set(
-      ptr   : string_ptr_t;
+      ptr   : ptr_t;
       index : integer;
-      value : character
+      value : val_t
     );
 
     impure function
     get(
-      ptr   : string_ptr_t;
+      ptr   : ptr_t;
       index : integer
-    ) return character;
+    ) return val_t;
 
     procedure
     reallocate(
-      ptr    : string_ptr_t;
+      ptr    : ptr_t;
       length : natural
     );
 
     procedure
     reallocate(
-      ptr   : string_ptr_t;
+      ptr   : ptr_t;
       value : string
     );
 
     procedure
     resize(
-      ptr    : string_ptr_t;
+      ptr    : ptr_t;
       length : natural;
       drop   : natural := 0
     );
 
     impure function
     to_string(
-      ptr : string_ptr_t
+      ptr : ptr_t
     ) return string;
   end protected;
 
   type string_ptr_storage_t is protected body
     variable current_index : integer := 0;
-    variable ptrs : string_access_vector_access_t := null;
+    variable ptrs : vava_t := null;
 
     impure function
     new_string_ptr(
       length : natural := 0
-    ) return string_ptr_t is
-      variable old_ptrs : string_access_vector_access_t;
-      variable retval : string_ptr_t := (index => current_index);
+    ) return ptr_t is
+      variable old_ptrs : vava_t;
+      variable retval : ptr_t := (index => current_index);
     begin
-
       if ptrs = null then
-        ptrs := new string_access_vector_t'(0 => null);
+        ptrs := new vav_t'(0 => null);
       elsif ptrs'length <= current_index then
         -- Reallocate ptr pointers to larger ptr
         -- Use more size to trade size for speed
         old_ptrs := ptrs;
-        ptrs := new string_access_vector_t'(0 to ptrs'length + 2**16 => null);
+        ptrs := new vav_t'(0 to ptrs'length + 2**16 => null);
         for i in old_ptrs'range loop
           ptrs(i) := old_ptrs(i);
         end loop;
         deallocate(old_ptrs);
       end if;
-
-      ptrs(current_index) := new string'(1 to length => character'low);
+      ptrs(current_index) := new string'(1 to length => val_t'low);
       current_index := current_index + 1;
       return retval;
     end;
 
     procedure
     deallocate(
-      ptr : string_ptr_t
+      ptr : ptr_t
     ) is begin
       deallocate(ptrs(ptr.index));
       ptrs(ptr.index) := null;
@@ -103,42 +101,42 @@ package body string_ptr_pkg is
 
     impure function
     length(
-      ptr : string_ptr_t
+      ptr : ptr_t
     ) return integer is begin
       return ptrs(ptr.index)'length;
     end;
 
     procedure
     set(
-      ptr   : string_ptr_t;
+      ptr   : ptr_t;
       index : integer;
-      value : character
+      value : val_t
     ) is begin
       ptrs(ptr.index)(index) := value;
     end;
 
     impure function
     get(
-      ptr   : string_ptr_t;
+      ptr   : ptr_t;
       index : integer
-    ) return character is begin
+    ) return val_t is begin
       return ptrs(ptr.index)(index);
     end;
 
     procedure
     reallocate(
-      ptr    : string_ptr_t;
+      ptr    : ptr_t;
       length : natural
     ) is
       variable old_ptr, new_ptr : string_access_t;
     begin
       deallocate(ptrs(ptr.index));
-      ptrs(ptr.index) := new string'(1 to length => character'low);
+      ptrs(ptr.index) := new string'(1 to length => val_t'low);
     end;
 
     procedure
     reallocate(
-      ptr   : string_ptr_t;
+      ptr   : ptr_t;
       value : string
     ) is
       variable old_ptr, new_ptr : string_access_t;
@@ -150,14 +148,14 @@ package body string_ptr_pkg is
 
     procedure
     resize(
-      ptr    : string_ptr_t;
+      ptr    : ptr_t;
       length : natural;
       drop   : natural := 0
     ) is
       variable old_ptr, new_ptr : string_access_t;
       variable min_length : natural := length;
     begin
-      new_ptr := new string'(1 to length => character'low);
+      new_ptr := new string'(1 to length => val_t'low);
       old_ptr := ptrs(ptr.index);
 
       if min_length > old_ptr'length - drop then
@@ -174,7 +172,7 @@ package body string_ptr_pkg is
 
     impure function
     to_string(
-      ptr : string_ptr_t
+      ptr : ptr_t
     ) return string is begin
       return ptrs(ptr.index).all;
     end;
@@ -185,7 +183,7 @@ package body string_ptr_pkg is
 
   function
   to_integer(
-    value : string_ptr_t
+    value : ptr_t
   ) return integer is begin
     return value.index;
   end;
@@ -193,7 +191,7 @@ package body string_ptr_pkg is
   impure function
   to_string_ptr(
     value : integer
-  ) return string_ptr_t is begin
+  ) return ptr_t is begin
     -- @TODO maybe assert that the index is valid
     return (index => value);
   end;
@@ -201,15 +199,15 @@ package body string_ptr_pkg is
   impure function
   new_string_ptr(
     length : natural := 0
-  ) return string_ptr_t is begin
+  ) return ptr_t is begin
     return string_ptr_storage.new_string_ptr(length);
   end;
 
   impure function
   new_string_ptr(
     value : string
-  ) return string_ptr_t is
-    variable result : string_ptr_t := new_string_ptr(value'length);
+  ) return ptr_t is
+    variable result : ptr_t := new_string_ptr(value'length);
     variable n_value : string(1 to value'length) := value;
   begin
     for i in 1 to n_value'length loop
@@ -220,7 +218,7 @@ package body string_ptr_pkg is
 
   procedure
   deallocate(
-    ptr : string_ptr_t
+    ptr : ptr_t
   ) is
   begin
     string_ptr_storage.deallocate(ptr);
@@ -228,44 +226,44 @@ package body string_ptr_pkg is
 
   impure function
   length(
-    ptr : string_ptr_t
+    ptr : ptr_t
   ) return integer is begin
     return string_ptr_storage.length(ptr);
   end;
 
   procedure
   set(
-    ptr   : string_ptr_t;
+    ptr   : ptr_t;
     index : integer;
-    value : character
+    value : val_t
   ) is begin
     string_ptr_storage.set(ptr, index, value);
   end;
 
   impure function
   get(
-    ptr : string_ptr_t;
+    ptr : ptr_t;
     index : integer
-  ) return character is begin
+  ) return val_t is begin
     return string_ptr_storage.get(ptr, index);
   end;
 
   procedure
   reallocate(
-    ptr : string_ptr_t;
+    ptr : ptr_t;
     length : natural
   ) is begin
     string_ptr_storage.reallocate(ptr, length);
   end;
 
-  procedure reallocate(ptr : string_ptr_t; value : string) is
+  procedure reallocate(ptr : ptr_t; value : string) is
   begin
     string_ptr_storage.reallocate(ptr, value);
   end;
 
   procedure
   resize(
-    ptr    : string_ptr_t;
+    ptr    : ptr_t;
     length : natural;
     drop   : natural := 0
   ) is begin
@@ -274,14 +272,14 @@ package body string_ptr_pkg is
 
   impure function
   to_string(
-    ptr : string_ptr_t
+    ptr : ptr_t
   ) return string is begin
     return string_ptr_storage.to_string(ptr);
   end;
 
   function
   encode(
-    data : string_ptr_t
+    data : ptr_t
   ) return string is begin
     return encode(data.index);
   end;
@@ -289,8 +287,8 @@ package body string_ptr_pkg is
   function
   decode(
     code : string
-  ) return string_ptr_t is
-    variable ret_val : string_ptr_t;
+  ) return ptr_t is
+    variable ret_val : ptr_t;
     variable index : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -301,7 +299,7 @@ package body string_ptr_pkg is
   decode(
     constant code : string;
     variable index : inout positive;
-    variable result : out string_ptr_t
+    variable result : out ptr_t
   ) is begin
     decode(code, index, result.index);
   end;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -6,55 +6,46 @@
 
 package body string_ptr_pkg is
   type string_ptr_storage_t is protected
-    impure function
-    new_string_ptr(
+    impure function new_string_ptr (
       length : natural := 0
     ) return natural;
 
-    procedure
-    deallocate(
+    procedure deallocate (
       ref : natural
     );
 
-    impure function
-    length(
+    impure function length (
       ref : natural
     ) return integer;
 
-    procedure
-    set(
+    procedure set (
       ref   : natural;
       index : natural;
       value : val_t
     );
 
-    impure function
-    get(
+    impure function get (
       ref   : natural;
       index : natural
     ) return val_t;
 
-    procedure
-    reallocate(
+    procedure reallocate (
       ref    : natural;
       length : natural
     );
 
-    procedure
-    reallocate(
+    procedure reallocate (
       ref   : natural;
       value : string
     );
 
-    procedure
-    resize(
+    procedure resize (
       ref    : natural;
       length : natural;
       drop   : natural := 0
     );
 
-    impure function
-    to_string(
+    impure function to_string (
       ref : natural
     ) return string;
   end protected;
@@ -63,8 +54,7 @@ package body string_ptr_pkg is
     variable current_index : integer := 0;
     variable ptrs : vava_t := null;
 
-    impure function
-    new_string_ptr(
+    impure function new_string_ptr (
       length : natural := 0
     ) return natural is
       variable old_ptrs : string_access_vector_access_t;
@@ -86,23 +76,20 @@ package body string_ptr_pkg is
       return current_index-1;
     end;
 
-    procedure
-    deallocate(
+    procedure deallocate (
       ref : natural
     ) is begin
       deallocate(ptrs(ref));
       ptrs(ref) := null;
     end;
 
-    impure function
-    length(
+    impure function length (
       ref : natural
     ) return integer is begin
       return ptrs(ref)'length;
     end;
 
-    procedure
-    set(
+    procedure set (
       ref   : natural;
       index : natural;
       value : val_t
@@ -110,16 +97,14 @@ package body string_ptr_pkg is
       ptrs(ref)(index) := value;
     end;
 
-    impure function
-    get(
+    impure function get (
       ref   : natural;
       index : natural
     ) return val_t is begin
       return ptrs(ref)(index);
     end;
 
-    procedure
-    reallocate(
+    procedure reallocate (
       ref    : natural;
       length : natural
     ) is
@@ -129,8 +114,7 @@ package body string_ptr_pkg is
       ptrs(ref) := new string'(1 to length => val_t'low);
     end;
 
-    procedure
-    reallocate(
+    procedure reallocate (
       ref   : natural;
       value : string
     ) is
@@ -141,8 +125,7 @@ package body string_ptr_pkg is
       ptrs(ref) := new string'(n_value);
     end;
 
-    procedure
-    resize(
+    procedure resize (
       ref    : natural;
       length : natural;
       drop   : natural := 0
@@ -152,21 +135,17 @@ package body string_ptr_pkg is
     begin
       new_ptr := new string'(1 to length => val_t'low);
       old_ptr := ptrs(ref);
-
       if min_length > old_ptr'length - drop then
         min_length := old_ptr'length - drop;
       end if;
-
       for i in 1 to min_length loop
         new_ptr(i) := old_ptr(drop + i);
       end loop;
-
       ptrs(ref) := new_ptr;
       deallocate(old_ptr);
     end;
 
-    impure function
-    to_string(
+    impure function to_string (
       ref : natural
     ) return string is begin
       return ptrs(ref).all;
@@ -176,30 +155,26 @@ package body string_ptr_pkg is
 
   shared variable string_ptr_storage : string_ptr_storage_t;
 
-  function
-  to_integer(
+  function to_integer (
     value : ptr_t
   ) return integer is begin
     return value.ref;
   end;
 
-  impure function
-  to_string_ptr(
+  impure function to_string_ptr (
     value : integer
   ) return ptr_t is begin
     -- @TODO maybe assert that the ref is valid
     return (ref => value);
   end;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     length : natural := 0
   ) return ptr_t is begin
     return (ref => string_ptr_storage.new_string_ptr(length));
   end;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     value : string
   ) return ptr_t is
     variable result : ptr_t := new_string_ptr(value'length);
@@ -211,23 +186,20 @@ package body string_ptr_pkg is
     return result;
   end;
 
-  procedure
-  deallocate(
+  procedure deallocate (
     ptr : ptr_t
   ) is
   begin
     string_ptr_storage.deallocate(ptr.ref);
   end;
 
-  impure function
-  length(
+  impure function length (
     ptr : ptr_t
   ) return integer is begin
     return string_ptr_storage.length(ptr.ref);
   end;
 
-  procedure
-  set(
+  procedure set (
     ptr   : ptr_t;
     index : natural;
     value : val_t
@@ -235,29 +207,28 @@ package body string_ptr_pkg is
     string_ptr_storage.set(ptr.ref, index, value);
   end;
 
-  impure function
-  get(
+  impure function get (
     ptr : ptr_t;
     index : natural
   ) return val_t is begin
     return string_ptr_storage.get(ptr.ref, index);
   end;
 
-  procedure
-  reallocate(
+  procedure reallocate (
     ptr : ptr_t;
     length : natural
   ) is begin
     string_ptr_storage.reallocate(ptr.ref, length);
   end;
 
-  procedure reallocate(ptr : ptr_t; value : string) is
-  begin
+  procedure reallocate (
+    ptr   : ptr_t;
+    value : string
+  ) is begin
     string_ptr_storage.reallocate(ptr.ref, value);
   end;
 
-  procedure
-  resize(
+  procedure resize (
     ptr    : ptr_t;
     length : natural;
     drop   : natural := 0
@@ -265,22 +236,19 @@ package body string_ptr_pkg is
     string_ptr_storage.resize(ptr.ref, length, drop);
   end;
 
-  impure function
-  to_string(
+  impure function to_string (
     ptr : ptr_t
   ) return string is begin
     return string_ptr_storage.to_string(ptr.ref);
   end;
 
-  function
-  encode(
+  function encode (
     data : ptr_t
   ) return string is begin
     return encode(data.ref);
   end;
 
-  function
-  decode(
+  function decode (
     code : string
   ) return ptr_t is
     variable ret_val : ptr_t;
@@ -290,8 +258,7 @@ package body string_ptr_pkg is
     return ret_val;
   end;
 
-  procedure
-  decode(
+  procedure decode (
     constant code : string;
     variable index : inout positive;
     variable result : out ptr_t

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
@@ -8,8 +8,7 @@ package body string_ptr_pkg is
   shared variable current_index : integer := 0;
   shared variable ptrs : vava_t := null;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     length : natural := 0
   ) return ptr_t is
     variable old_ptrs : vava_t;
@@ -32,23 +31,20 @@ package body string_ptr_pkg is
     return retval;
   end;
 
-  procedure
-  deallocate(
+  procedure deallocate (
     ptr : ptr_t
   ) is begin
     deallocate(ptrs(ptr.ref));
     ptrs(ptr.ref) := null;
   end;
 
-  impure function
-  length(
+  impure function length (
     ptr : ptr_t
   ) return integer is begin
     return ptrs(ptr.ref)'length;
   end;
 
-  procedure
-  set(
+  procedure set (
     ptr   : ptr_t;
     index : natural;
     value : val_t
@@ -56,16 +52,14 @@ package body string_ptr_pkg is
     ptrs(ptr.ref)(index) := value;
   end;
 
-  impure function
-  get(
+  impure function get (
     ptr   : ptr_t;
     index : natural
   ) return val_t is begin
     return ptrs(ptr.ref)(index);
   end;
 
-  procedure
-  reallocate(
+  procedure reallocate (
     ptr    : ptr_t;
     length : natural
   ) is
@@ -75,8 +69,7 @@ package body string_ptr_pkg is
     ptrs(ptr.ref) := new string'(1 to length => val_t'low);
   end;
 
-  procedure
-  reallocate(
+  procedure reallocate (
     ptr   : ptr_t;
     value : string
   ) is
@@ -87,8 +80,7 @@ package body string_ptr_pkg is
     ptrs(ptr.ref) := new string'(n_value);
   end;
 
-  procedure
-  resize(
+  procedure resize (
     ptr    : ptr_t;
     length : natural;
     drop   : natural := 0
@@ -98,43 +90,36 @@ package body string_ptr_pkg is
   begin
     new_ptr := new string'(1 to length => val_t'low);
     old_ptr := ptrs(ptr.ref);
-
     if min_length > old_ptr'length - drop then
       min_length := old_ptr'length - drop;
     end if;
-
     for i in 1 to min_length loop
       new_ptr(i) := old_ptr(drop + i);
     end loop;
-
     ptrs(ptr.ref) := new_ptr;
     deallocate(old_ptr);
   end;
 
-  impure function
-  to_string(
+  impure function to_string (
     ptr : ptr_t
   ) return string is begin
     return ptrs(ptr.ref).all;
   end;
 
-  function
-  to_integer(
+  function to_integer (
     value : ptr_t
   ) return integer is begin
     return value.ref;
   end;
 
-  impure function
-  to_string_ptr(
+  impure function to_string_ptr (
     value : integer
   ) return ptr_t is begin
     -- @TODO maybe assert that the ref is valid
     return (ref => value);
   end;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     value : string
   ) return ptr_t is
     variable result : ptr_t := new_string_ptr(value'length);
@@ -146,15 +131,13 @@ package body string_ptr_pkg is
     return result;
   end;
 
-  function
-  encode(
+  function encode (
     data : ptr_t
   ) return string is begin
     return encode(data.ref);
   end;
 
-  function
-  decode(
+  function decode (
     code : string
   ) return ptr_t is
     variable ret_val : ptr_t;
@@ -164,8 +147,7 @@ package body string_ptr_pkg is
     return ret_val;
   end;
 
-  procedure
-  decode(
+  procedure decode (
     constant code   : string;
     variable index  : inout positive;
     variable result : out ptr_t

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
@@ -13,7 +13,7 @@ package body string_ptr_pkg is
     length : natural := 0
   ) return ptr_t is
     variable old_ptrs : vava_t;
-    variable retval : ptr_t := (index => current_index);
+    variable retval : ptr_t := (ref => current_index);
   begin
     if ptrs = null then
       ptrs := new vav_t'(0 => null);
@@ -36,15 +36,15 @@ package body string_ptr_pkg is
   deallocate(
     ptr : ptr_t
   ) is begin
-    deallocate(ptrs(ptr.index));
-    ptrs(ptr.index) := null;
+    deallocate(ptrs(ptr.ref));
+    ptrs(ptr.ref) := null;
   end;
 
   impure function
   length(
     ptr : ptr_t
   ) return integer is begin
-    return ptrs(ptr.index)'length;
+    return ptrs(ptr.ref)'length;
   end;
 
   procedure
@@ -53,7 +53,7 @@ package body string_ptr_pkg is
     index : integer;
     value : val_t
   ) is begin
-    ptrs(ptr.index)(index) := value;
+    ptrs(ptr.ref)(index) := value;
   end;
 
   impure function
@@ -61,7 +61,7 @@ package body string_ptr_pkg is
     ptr   : ptr_t;
     index : integer
   ) return val_t is begin
-    return ptrs(ptr.index)(index);
+    return ptrs(ptr.ref)(index);
   end;
 
   procedure
@@ -71,8 +71,8 @@ package body string_ptr_pkg is
   ) is
     variable old_ptr, new_ptr : string_access_t;
   begin
-    deallocate(ptrs(ptr.index));
-    ptrs(ptr.index) := new string'(1 to length => val_t'low);
+    deallocate(ptrs(ptr.ref));
+    ptrs(ptr.ref) := new string'(1 to length => val_t'low);
   end;
 
   procedure
@@ -83,8 +83,8 @@ package body string_ptr_pkg is
     variable old_ptr, new_ptr : string_access_t;
     variable n_value : string(1 to value'length) := value;
   begin
-    deallocate(ptrs(ptr.index));
-    ptrs(ptr.index) := new string'(n_value);
+    deallocate(ptrs(ptr.ref));
+    ptrs(ptr.ref) := new string'(n_value);
   end;
 
   procedure
@@ -97,7 +97,7 @@ package body string_ptr_pkg is
     variable min_length : natural := length;
   begin
     new_ptr := new string'(1 to length => val_t'low);
-    old_ptr := ptrs(ptr.index);
+    old_ptr := ptrs(ptr.ref);
 
     if min_length > old_ptr'length - drop then
       min_length := old_ptr'length - drop;
@@ -107,7 +107,7 @@ package body string_ptr_pkg is
       new_ptr(i) := old_ptr(drop + i);
     end loop;
 
-    ptrs(ptr.index) := new_ptr;
+    ptrs(ptr.ref) := new_ptr;
     deallocate(old_ptr);
   end;
 
@@ -115,22 +115,22 @@ package body string_ptr_pkg is
   to_string(
     ptr : ptr_t
   ) return string is begin
-    return ptrs(ptr.index).all;
+    return ptrs(ptr.ref).all;
   end;
 
   function
   to_integer(
     value : ptr_t
   ) return integer is begin
-    return value.index;
+    return value.ref;
   end;
 
   impure function
   to_string_ptr(
     value : integer
   ) return ptr_t is begin
-    -- @TODO maybe assert that the index is valid
-    return (index => value);
+    -- @TODO maybe assert that the ref is valid
+    return (ref => value);
   end;
 
   impure function
@@ -150,7 +150,7 @@ package body string_ptr_pkg is
   encode(
     data : ptr_t
   ) return string is begin
-    return encode(data.index);
+    return encode(data.ref);
   end;
 
   function
@@ -170,7 +170,7 @@ package body string_ptr_pkg is
     variable index  : inout positive;
     variable result : out ptr_t
   ) is begin
-    decode(code, index, result.index);
+    decode(code, index, result.ref);
   end;
 
 end package body;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
@@ -12,11 +12,13 @@ package body string_ptr_pkg is
   shared variable current_index : integer := 0;
   shared variable ptrs : string_access_vector_access_t := null;
 
-  impure function new_string_ptr(length : natural := 0) return string_ptr_t is
+  impure function
+  new_string_ptr(
+    length : natural := 0
+  ) return string_ptr_t is
     variable old_ptrs : string_access_vector_access_t;
     variable retval : string_ptr_t := (index => current_index);
   begin
-
     if ptrs = null then
       ptrs := new string_access_vector_t'(0 => null);
     elsif ptrs'length <= current_index then
@@ -29,49 +31,72 @@ package body string_ptr_pkg is
       end loop;
       deallocate(old_ptrs);
     end if;
-
     ptrs(current_index) := new string'(1 to length => character'low);
     current_index := current_index + 1;
     return retval;
-  end function;
+  end;
 
-  procedure deallocate(ptr : string_ptr_t) is
-  begin
+  procedure
+  deallocate(
+    ptr : string_ptr_t
+  ) is begin
     deallocate(ptrs(ptr.index));
     ptrs(ptr.index) := null;
-  end procedure;
+  end;
 
-  impure function length(ptr : string_ptr_t) return integer is
-  begin
+  impure function
+  length(
+    ptr : string_ptr_t
+  ) return integer is begin
     return ptrs(ptr.index)'length;
-  end function;
+  end;
 
-  procedure set(ptr : string_ptr_t; index : integer; value : character) is
-  begin
+  procedure
+  set(
+    ptr   : string_ptr_t;
+    index : integer;
+    value : character
+  ) is begin
     ptrs(ptr.index)(index) := value;
-  end procedure;
+  end;
 
-  impure function get(ptr : string_ptr_t; index : integer) return character is
-  begin
+  impure function
+  get(
+    ptr   : string_ptr_t;
+    index : integer
+  ) return character is begin
     return ptrs(ptr.index)(index);
-  end function;
+  end;
 
-  procedure reallocate(ptr : string_ptr_t; length : natural) is
+  procedure
+  reallocate(
+    ptr    : string_ptr_t;
+    length : natural
+  ) is
     variable old_ptr, new_ptr : string_access_t;
   begin
     deallocate(ptrs(ptr.index));
     ptrs(ptr.index) := new string'(1 to length => character'low);
-  end procedure;
+  end;
 
-  procedure reallocate(ptr : string_ptr_t; value : string) is
+  procedure
+  reallocate(
+    ptr   : string_ptr_t;
+    value : string
+  ) is
     variable old_ptr, new_ptr : string_access_t;
     variable n_value : string(1 to value'length) := value;
   begin
     deallocate(ptrs(ptr.index));
     ptrs(ptr.index) := new string'(n_value);
-  end procedure;
+  end;
 
-  procedure resize(ptr : string_ptr_t; length : natural; drop : natural := 0) is
+  procedure
+  resize(
+    ptr    : string_ptr_t;
+    length : natural;
+    drop   : natural := 0
+  ) is
     variable old_ptr, new_ptr : string_access_t;
     variable min_length : natural := length;
   begin
@@ -88,25 +113,34 @@ package body string_ptr_pkg is
 
     ptrs(ptr.index) := new_ptr;
     deallocate(old_ptr);
-  end procedure;
+  end;
 
-  impure function to_string(ptr : string_ptr_t) return string is
-  begin
+  impure function
+  to_string(
+    ptr : string_ptr_t
+  ) return string is begin
     return ptrs(ptr.index).all;
   end;
 
-  function to_integer(value : string_ptr_t) return integer is
-  begin
+  function
+  to_integer(
+    value : string_ptr_t
+  ) return integer is begin
     return value.index;
-  end function;
+  end;
 
-  impure function to_string_ptr(value : integer) return string_ptr_t is
-  begin
+  impure function
+  to_string_ptr(
+    value : integer
+  ) return string_ptr_t is begin
     -- @TODO maybe assert that the index is valid
     return (index => value);
-  end function;
+  end;
 
-  impure function new_string_ptr(value : string) return string_ptr_t is
+  impure function
+  new_string_ptr(
+    value : string
+  ) return string_ptr_t is
     variable result : string_ptr_t := new_string_ptr(value'length);
     variable n_value : string(1 to value'length) := value;
   begin
@@ -114,24 +148,32 @@ package body string_ptr_pkg is
       set(result, i, n_value(i));
     end loop;
     return result;
-  end function;
+  end;
 
-  function encode(data : string_ptr_t) return string is
-  begin
+  function
+  encode(
+    data : string_ptr_t
+  ) return string is begin
     return encode(data.index);
   end;
 
-  function decode(code : string) return string_ptr_t is
+  function
+  decode(
+    code : string
+  ) return string_ptr_t is
     variable ret_val : string_ptr_t;
-    variable index : positive := code'left;
+    variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
-
     return ret_val;
   end;
 
-  procedure decode (constant code : string; variable index : inout positive; variable result : out string_ptr_t) is
-  begin
+  procedure
+  decode(
+    constant code   : string;
+    variable index  : inout positive;
+    variable result : out string_ptr_t
+  ) is begin
     decode(code, index, result.index);
   end;
 

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
@@ -50,7 +50,7 @@ package body string_ptr_pkg is
   procedure
   set(
     ptr   : ptr_t;
-    index : integer;
+    index : natural;
     value : val_t
   ) is begin
     ptrs(ptr.ref)(index) := value;
@@ -59,7 +59,7 @@ package body string_ptr_pkg is
   impure function
   get(
     ptr   : ptr_t;
-    index : integer
+    index : natural
   ) return val_t is begin
     return ptrs(ptr.ref)(index);
   end;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
@@ -10,35 +10,35 @@ package body string_ptr_pkg is
   type string_access_vector_access_t is access string_access_vector_t;
 
   shared variable current_index : integer := 0;
-  shared variable ptrs : string_access_vector_access_t := null;
+  shared variable ptrs : vava_t := null;
 
   impure function
   new_string_ptr(
     length : natural := 0
-  ) return string_ptr_t is
-    variable old_ptrs : string_access_vector_access_t;
-    variable retval : string_ptr_t := (index => current_index);
+  ) return ptr_t is
+    variable old_ptrs : vava_t;
+    variable retval : ptr_t := (index => current_index);
   begin
     if ptrs = null then
-      ptrs := new string_access_vector_t'(0 => null);
+      ptrs := new vav_t'(0 => null);
     elsif ptrs'length <= current_index then
       -- Reallocate ptr pointers to larger ptr
       -- Use more size to trade size for speed
       old_ptrs := ptrs;
-      ptrs := new string_access_vector_t'(0 to ptrs'length + 2**16 => null);
+      ptrs := new vav_t'(0 to ptrs'length + 2**16 => null);
       for i in old_ptrs'range loop
         ptrs(i) := old_ptrs(i);
       end loop;
       deallocate(old_ptrs);
     end if;
-    ptrs(current_index) := new string'(1 to length => character'low);
+    ptrs(current_index) := new string'(1 to length => val_t'low);
     current_index := current_index + 1;
     return retval;
   end;
 
   procedure
   deallocate(
-    ptr : string_ptr_t
+    ptr : ptr_t
   ) is begin
     deallocate(ptrs(ptr.index));
     ptrs(ptr.index) := null;
@@ -46,42 +46,42 @@ package body string_ptr_pkg is
 
   impure function
   length(
-    ptr : string_ptr_t
+    ptr : ptr_t
   ) return integer is begin
     return ptrs(ptr.index)'length;
   end;
 
   procedure
   set(
-    ptr   : string_ptr_t;
+    ptr   : ptr_t;
     index : integer;
-    value : character
+    value : val_t
   ) is begin
     ptrs(ptr.index)(index) := value;
   end;
 
   impure function
   get(
-    ptr   : string_ptr_t;
+    ptr   : ptr_t;
     index : integer
-  ) return character is begin
+  ) return val_t is begin
     return ptrs(ptr.index)(index);
   end;
 
   procedure
   reallocate(
-    ptr    : string_ptr_t;
+    ptr    : ptr_t;
     length : natural
   ) is
     variable old_ptr, new_ptr : string_access_t;
   begin
     deallocate(ptrs(ptr.index));
-    ptrs(ptr.index) := new string'(1 to length => character'low);
+    ptrs(ptr.index) := new string'(1 to length => val_t'low);
   end;
 
   procedure
   reallocate(
-    ptr   : string_ptr_t;
+    ptr   : ptr_t;
     value : string
   ) is
     variable old_ptr, new_ptr : string_access_t;
@@ -93,14 +93,14 @@ package body string_ptr_pkg is
 
   procedure
   resize(
-    ptr    : string_ptr_t;
+    ptr    : ptr_t;
     length : natural;
     drop   : natural := 0
   ) is
     variable old_ptr, new_ptr : string_access_t;
     variable min_length : natural := length;
   begin
-    new_ptr := new string'(1 to length => character'low);
+    new_ptr := new string'(1 to length => val_t'low);
     old_ptr := ptrs(ptr.index);
 
     if min_length > old_ptr'length - drop then
@@ -117,14 +117,14 @@ package body string_ptr_pkg is
 
   impure function
   to_string(
-    ptr : string_ptr_t
+    ptr : ptr_t
   ) return string is begin
     return ptrs(ptr.index).all;
   end;
 
   function
   to_integer(
-    value : string_ptr_t
+    value : ptr_t
   ) return integer is begin
     return value.index;
   end;
@@ -132,7 +132,7 @@ package body string_ptr_pkg is
   impure function
   to_string_ptr(
     value : integer
-  ) return string_ptr_t is begin
+  ) return ptr_t is begin
     -- @TODO maybe assert that the index is valid
     return (index => value);
   end;
@@ -140,8 +140,8 @@ package body string_ptr_pkg is
   impure function
   new_string_ptr(
     value : string
-  ) return string_ptr_t is
-    variable result : string_ptr_t := new_string_ptr(value'length);
+  ) return ptr_t is
+    variable result : ptr_t := new_string_ptr(value'length);
     variable n_value : string(1 to value'length) := value;
   begin
     for i in 1 to n_value'length loop
@@ -152,7 +152,7 @@ package body string_ptr_pkg is
 
   function
   encode(
-    data : string_ptr_t
+    data : ptr_t
   ) return string is begin
     return encode(data.index);
   end;
@@ -160,8 +160,8 @@ package body string_ptr_pkg is
   function
   decode(
     code : string
-  ) return string_ptr_t is
-    variable ret_val : string_ptr_t;
+  ) return ptr_t is
+    variable ret_val : ptr_t;
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -172,7 +172,7 @@ package body string_ptr_pkg is
   decode(
     constant code   : string;
     variable index  : inout positive;
-    variable result : out string_ptr_t
+    variable result : out ptr_t
   ) is begin
     decode(code, index, result.index);
   end;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
@@ -5,10 +5,6 @@
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 package body string_ptr_pkg is
-  type string_access_t is access string;
-  type string_access_vector_t is array (natural range <>) of string_access_t;
-  type string_access_vector_access_t is access string_access_vector_t;
-
   shared variable current_index : integer := 0;
   shared variable ptrs : vava_t := null;
 

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -27,85 +27,70 @@ package string_ptr_pkg is
   alias  vav_t  is string_access_vector_t;
   alias  vava_t is string_access_vector_access_t;
 
-  function
-  to_integer(
+  function to_integer (
     value : string_ptr_t
   ) return integer;
 
-  impure function
-  to_string_ptr(
+  impure function to_string_ptr (
     value : integer
   ) return string_ptr_t;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     length : natural := 0
   ) return string_ptr_t;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     value : string
   ) return string_ptr_t;
 
-  procedure
-  deallocate(
+  procedure deallocate (
     ptr : string_ptr_t
   );
 
-  impure function
-  length(
+  impure function length (
     ptr : string_ptr_t
   ) return integer;
 
-  procedure
-  set(
+  procedure set (
     ptr   : string_ptr_t;
     index : natural;
     value : character
   );
 
-  impure function
-  get(
+  impure function get (
     ptr   : string_ptr_t;
     index : natural
   ) return character;
 
-  procedure
-  reallocate(
+  procedure reallocate (
     ptr    : string_ptr_t;
     length : natural
   );
 
-  procedure
-  reallocate(
+  procedure reallocate (
     ptr   : string_ptr_t;
     value : string
   );
 
-  procedure
-  resize(
+  procedure resize (
     ptr    : string_ptr_t;
     length : natural;
     drop   : natural := 0
   );
 
-  impure function
-  to_string(
+  impure function to_string (
     ptr : string_ptr_t
   ) return string;
 
-  function
-  encode(
+  function encode (
     data : string_ptr_t
   ) return string;
 
-  function
-  decode(
+  function decode (
     code : string
   ) return string_ptr_t;
 
-  procedure
-  decode(
+  procedure decode (
     constant code   : string;
     variable index  : inout positive;
     variable result : out string_ptr_t

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -60,14 +60,14 @@ package string_ptr_pkg is
   procedure
   set(
     ptr   : string_ptr_t;
-    index : integer;
+    index : natural;
     value : character
   );
 
   impure function
   get(
     ptr   : string_ptr_t;
-    index : integer
+    index : natural
   ) return character;
 
   procedure

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -20,6 +20,11 @@ package string_ptr_pkg is
   end record;
   constant null_string_ptr : string_ptr_t := (index => -1);
 
+  alias  ptr_t  is string_ptr_t;
+  alias  val_t  is character;
+  alias  vav_t  is string_access_vector_t;
+  alias  vava_t is string_access_vector_access_t;
+
   function
   to_integer(
     value : string_ptr_t

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -18,9 +18,9 @@ use work.codec_builder_pkg.all;
 package string_ptr_pkg is
   subtype index_t is integer range -1 to integer'high;
   type string_ptr_t is record
-    index : index_t;
+    ref : index_t;
   end record;
-  constant null_string_ptr : string_ptr_t := (index => -1);
+  constant null_string_ptr : string_ptr_t := (ref => -1);
 
   alias  ptr_t  is string_ptr_t;
   alias  val_t  is character;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -20,23 +20,93 @@ package string_ptr_pkg is
   end record;
   constant null_string_ptr : string_ptr_t := (index => -1);
 
-  function to_integer(value : string_ptr_t) return integer;
-  impure function to_string_ptr(value : integer) return string_ptr_t;
-  impure function new_string_ptr(length : natural := 0) return string_ptr_t;
-  impure function new_string_ptr(value : string) return string_ptr_t;
-  procedure deallocate(ptr : string_ptr_t);
-  impure function length(ptr : string_ptr_t) return integer;
-  procedure set(ptr : string_ptr_t; index : integer; value : character);
-  impure function get(ptr : string_ptr_t; index : integer) return character;
-  procedure reallocate(ptr : string_ptr_t; length : natural);
-  procedure reallocate(ptr : string_ptr_t; value : string);
-  procedure resize(ptr : string_ptr_t; length : natural; drop : natural := 0);
-  impure function to_string(ptr : string_ptr_t) return string;
-  constant string_ptr_t_code_length : positive := integer_code_length;
-  function encode(data : string_ptr_t) return string;
-  function decode(code : string) return string_ptr_t;
-  procedure decode (constant code : string; variable index : inout positive; variable result : out string_ptr_t);
+  function
+  to_integer(
+    value : string_ptr_t
+  ) return integer;
+
+  impure function
+  to_string_ptr(
+    value : integer
+  ) return string_ptr_t;
+
+  impure function
+  new_string_ptr(
+    length : natural := 0
+  ) return string_ptr_t;
+
+  impure function
+  new_string_ptr(
+    value : string
+  ) return string_ptr_t;
+
+  procedure
+  deallocate(
+    ptr : string_ptr_t
+  );
+
+  impure function
+  length(
+    ptr : string_ptr_t
+  ) return integer;
+
+  procedure
+  set(
+    ptr   : string_ptr_t;
+    index : integer;
+    value : character
+  );
+
+  impure function
+  get(
+    ptr   : string_ptr_t;
+    index : integer
+  ) return character;
+
+  procedure
+  reallocate(
+    ptr    : string_ptr_t;
+    length : natural
+  );
+
+  procedure
+  reallocate(
+    ptr   : string_ptr_t;
+    value : string
+  );
+
+  procedure
+  resize(
+    ptr    : string_ptr_t;
+    length : natural;
+    drop   : natural := 0
+  );
+
+  impure function
+  to_string(
+    ptr : string_ptr_t
+  ) return string;
+
+  function
+  encode(
+    data : string_ptr_t
+  ) return string;
+
+  function
+  decode(
+    code : string
+  ) return string_ptr_t;
+
+  procedure
+  decode(
+    constant code   : string;
+    variable index  : inout positive;
+    variable result : out string_ptr_t
+  );
+
   alias encode_string_ptr_t is encode[string_ptr_t return string];
   alias decode_string_ptr_t is decode[string return string_ptr_t];
+
+  constant string_ptr_t_code_length : positive := integer_code_length;
 
 end package;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -10,6 +10,8 @@
 -- into a singleton datastructure of string access types.
 --
 
+use work.string_pkg.all;
+
 use work.codec_pkg.all;
 use work.codec_builder_pkg.all;
 

--- a/vunit/vhdl/data_types/src/string_ptr_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pool_pkg.vhd
@@ -7,32 +7,50 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-
 use work.string_ptr_pkg.all;
 use work.queue_pkg.all;
 
 package string_ptr_pool_pkg is
-
   type string_ptr_pool_t is record
     ptrs : queue_t;
   end record;
   constant null_string_ptr_pool : string_ptr_pool_t := (others => null_queue);
 
-  impure function new_string_ptr_pool return string_ptr_pool_t;
-  impure function new_string_ptr(pool : string_ptr_pool_t; min_length : natural := 0) return string_ptr_t;
-  impure function new_string_ptr(pool : string_ptr_pool_t; value : string) return string_ptr_t;
-  procedure recycle(pool : string_ptr_pool_t; variable ptr : inout string_ptr_t);
+  impure function
+  new_string_ptr_pool
+  return string_ptr_pool_t;
 
+  impure function
+  new_string_ptr(
+    pool       : string_ptr_pool_t;
+    min_length : natural := 0
+  ) return string_ptr_t;
+
+  impure function
+  new_string_ptr(
+    pool  : string_ptr_pool_t;
+    value : string
+  ) return string_ptr_t;
+
+  procedure
+  recycle(
+    pool : string_ptr_pool_t;
+    variable ptr : inout string_ptr_t
+  );
 end package;
 
 package body string_ptr_pool_pkg is
-
-  impure function new_string_ptr_pool return string_ptr_pool_t is
-  begin
+  impure function
+  new_string_ptr_pool
+  return string_ptr_pool_t is begin
     return (ptrs => new_queue);
   end;
 
-  impure function new_string_ptr(pool : string_ptr_pool_t; min_length : natural := 0) return string_ptr_t is
+  impure function
+  new_string_ptr(
+    pool       : string_ptr_pool_t;
+    min_length : natural := 0
+  ) return string_ptr_t is
     variable ptr : string_ptr_t;
   begin
     if length(pool.ptrs) > 0 then
@@ -50,7 +68,11 @@ package body string_ptr_pool_pkg is
     return ptr;
   end;
 
-  impure function new_string_ptr(pool : string_ptr_pool_t; value : string) return string_ptr_t is
+  impure function
+  new_string_ptr(
+    pool  : string_ptr_pool_t;
+    value : string
+  ) return string_ptr_t is
     variable ptr : string_ptr_t;
   begin
     if length(pool.ptrs) > 0 then
@@ -64,14 +86,15 @@ package body string_ptr_pool_pkg is
     return ptr;
   end;
 
-  procedure recycle(pool : string_ptr_pool_t; variable ptr : inout string_ptr_t) is
-  begin
+  procedure
+  recycle(
+    pool : string_ptr_pool_t;
+    variable ptr : inout string_ptr_t
+  ) is begin
     if ptr = null_string_ptr then
       return;
     end if;
-
     push(pool.ptrs, to_integer(ptr));
     ptr := null_string_ptr;
-  end procedure;
-
+  end;
 end package body;

--- a/vunit/vhdl/data_types/src/string_ptr_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pool_pkg.vhd
@@ -16,38 +16,32 @@ package string_ptr_pool_pkg is
   end record;
   constant null_string_ptr_pool : string_ptr_pool_t := (others => null_queue);
 
-  impure function
-  new_string_ptr_pool
+  impure function new_string_ptr_pool
   return string_ptr_pool_t;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     pool       : string_ptr_pool_t;
     min_length : natural := 0
   ) return string_ptr_t;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     pool  : string_ptr_pool_t;
     value : string
   ) return string_ptr_t;
 
-  procedure
-  recycle(
+  procedure recycle (
     pool : string_ptr_pool_t;
     variable ptr : inout string_ptr_t
   );
 end package;
 
 package body string_ptr_pool_pkg is
-  impure function
-  new_string_ptr_pool
+  impure function new_string_ptr_pool
   return string_ptr_pool_t is begin
     return (ptrs => new_queue);
   end;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     pool       : string_ptr_pool_t;
     min_length : natural := 0
   ) return string_ptr_t is
@@ -56,20 +50,17 @@ package body string_ptr_pool_pkg is
     if length(pool.ptrs) > 0 then
       -- Reuse
       ptr := to_string_ptr(pop(pool.ptrs));
-
       if length(ptr) < min_length then
         reallocate(ptr, min_length);
       end if;
     else
-
       -- Allocate new
       ptr := new_string_ptr(min_length);
     end if;
     return ptr;
   end;
 
-  impure function
-  new_string_ptr(
+  impure function new_string_ptr (
     pool  : string_ptr_pool_t;
     value : string
   ) return string_ptr_t is
@@ -86,8 +77,7 @@ package body string_ptr_pool_pkg is
     return ptr;
   end;
 
-  procedure
-  recycle(
+  procedure recycle (
     pool : string_ptr_pool_t;
     variable ptr : inout string_ptr_t
   ) is begin

--- a/vunit/vhdl/data_types/src/types/integer_vector_pkg.vhd
+++ b/vunit/vhdl/data_types/src/types/integer_vector_pkg.vhd
@@ -1,0 +1,12 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+package integer_vector_pkg is
+  type integer_vector_t is array (natural range <>) of integer;
+  type integer_vector_access_t is access integer_vector_t;
+  type integer_vector_access_vector_t is array (natural range <>) of integer_vector_access_t;
+  type integer_vector_access_vector_access_t is access integer_vector_access_vector_t;
+end package;

--- a/vunit/vhdl/data_types/src/types/string_pkg.vhd
+++ b/vunit/vhdl/data_types/src/types/string_pkg.vhd
@@ -1,0 +1,11 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+package string_pkg is
+  type string_access_t is access string;
+  type string_access_vector_t is array (natural range <>) of string_access_t;
+  type string_access_vector_access_t is access string_access_vector_t;
+end package;

--- a/vunit/vhdl/logging/src/file_pkg.vhd
+++ b/vunit/vhdl/logging/src/file_pkg.vhd
@@ -29,7 +29,7 @@ end package;
 
 package body file_pkg is
 
-  constant next_id : integer_vector_ptr_t := new_integer_vector_ptr(length => 1, value => 0);
+  constant next_id : integer_vector_ptr_t := new_integer_vector_ptr(len => 1, value => 0);
 
   constant id_idx : natural := 0;
   constant open_idx : natural := 1;
@@ -153,7 +153,7 @@ package body file_pkg is
       id := get(next_id, 0);
       set(next_id, 0, id + 1);
 
-      file_id.p_data := new_integer_vector_ptr(length => file_id_length);
+      file_id.p_data := new_integer_vector_ptr(len => file_id_length);
       set(file_id.p_data, id_idx, id);
       set(file_id.p_data, name_idx, to_integer(new_string_ptr(file_name)));
     else

--- a/vunit/vhdl/logging/src/logger_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/logger_pkg-body.vhd
@@ -123,7 +123,7 @@ package body logger_pkg is
 
     if log_level_filter = null_ptr then
       -- Only show valid log levels by default
-      log_level_filter := new_integer_vector_ptr(length => n_log_levels, value => log_level_invisible);
+      log_level_filter := new_integer_vector_ptr(len => n_log_levels, value => log_level_invisible);
       for log_level in log_level_t'low to log_level_t'high loop
         if is_valid(log_level) then
           set(log_level_filter, log_level_t'pos(log_level), log_level_visible);

--- a/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
@@ -142,7 +142,7 @@ package body axi_slave_private_pkg is
       p_axi_slave_type := axi_slave_type;
       p_data_size := data'length/8;
       p_max_id := max_id;
-      p_id_indexes := new_integer_vector_ptr(length => max_id+1, value => 0);
+      p_id_indexes := new_integer_vector_ptr(len => max_id+1, value => 0);
       p_burst_queue_max_length := axi_slave.p_initial_address_fifo_depth;
       p_burst_queue := new_queue;
       p_burst_queue_length := 0;


### PR DESCRIPTION
This PR is based on #481 and it should be merged later.

This PR is work-in-progress towards #476 and #470.

- The style of functions and procedures in almost all the sources in `vunit/vhdl/data_types/src` is modified:

``` vhdl
function
func_name(
  paramA : typeofparamA
) return typeofreturn;
```

- `end function;` and `end procedure;` are replaced with `end;` for coherency.

- Aliases are added to `integer_vector_ptr` and `string_ptr` in order to highlight the similarities between these files. Compare, e.g., `integer_vector_ptr_pkg-body-200x.vhd` and `string_ptr_pkg-body-200x.vhd` before and after this PR:

```
Added(4,28)  Deleted(0,19) Changed(88) Changed in changed(71)
Added(40,16) Deleted(0,25) Changed(63) Changed in changed(43)
```

- The definition of types `integer_vector_t`, `integer_vector_access_t`, `string_ptr_access_t`, etc. are moved to separate packages in a new subdir (`vunit/vhdl/data_types/src/types`). This is because, in the future, packages to support external models will depend on these types, and `integer_vector_ptr_pkg`/`string_ptr_pkg` will depend on the external models (or their placeholders).

- In the VHDL 2008 sources, there is no need to use custom types for the pointers. 'natural' is used instead.

- When external models are added, the variable inside the pointer types will not be an explicit index. I think that `ref` is a better name.

- GHDL drops a lot of warnings because declaring parameter `length` hides the function name. Options are renamed to `len` to avoid it.

- Parameter `index` used in `get` and `set` is declared as of type `integer`. However, it should be `natural`, because it is not possible to access to negative indexes.